### PR TITLE
fixed ase calc not accounting for cell and particle number changes

### DIFF
--- a/gmnn_jax/md/ase_calc.py
+++ b/gmnn_jax/md/ase_calc.py
@@ -81,7 +81,7 @@ class ASECalculator(Calculator):
     def calculate(self, atoms, properties=["energy"], system_changes=all_changes):
         Calculator.calculate(self, atoms, properties, system_changes)
 
-        if self.step is None:
+        if self.step is None or "numbers" in system_changes or "cell" in all_changes:
             self.initialize(atoms)
             self.neighbors = self.neighbor_fn.allocate(atoms.positions)
             energy, forces, self.neighbors = self.step(atoms.positions, self.neighbors)


### PR DESCRIPTION
Now the ase calc simply triggers a recompilation on either of these changes. In the future we may want to look into how NPT simulations work with JaxMD.

Closes #21 