### PR TITLE
Validate config command

### DIFF
--- a/gmnn_jax/cli/gmnn_app.py
+++ b/gmnn_jax/cli/gmnn_app.py
@@ -7,7 +7,6 @@ from pydantic import ValidationError
 from rich.console import Console
 
 console = Console(highlight=False)
-
 app = typer.Typer(context_settings={"help_option_names": ["-h", "--help"]})
 validate_app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
@@ -123,9 +122,22 @@ def validate_md_config(
         console.print(f"{config_path} is a valid MD config.")
 
 
+logo = """
+[bold white]  /######  /##      /## /##   /## /##   /##[bold turquoise2]            /#####  /######  /##   /##
+[bold white] /##__  ##| ###    /###| ### | ##| ### | ##[bold turquoise2]           |__  ## /##__  ##| ##  / ##
+[bold white]| ##  \__/| ####  /####| ####| ##| ####| ##[bold turquoise2]              | ##| ##  \ ##|  ##/ ##/
+[bold white]| ## /####| ## ##/## ##| ## ## ##| ## ## ##[bold turquoise2] /######      | ##| ######## \  ####/ 
+[bold white]| ##|_  ##| ##  ###| ##| ##  ####| ##  ####[bold turquoise2]|______/ /##  | ##| ##__  ##  >##  ## 
+[bold white]| ##  \ ##| ##\  # | ##| ##\  ###| ##\  ###[bold turquoise2]        | ##  | ##| ##  | ## /##/\  ##
+[bold white]|  ######/| ## \/  | ##| ## \  ##| ## \  ##[bold turquoise2]        |  ######/| ##  | ##| ##  \ ##
+[bold white] \______/ |__/     |__/|__/  \__/|__/  \__/[bold turquoise2]         \______/ |__/  |__/|__/  |__/
+"""  # noqa: E501, W605, W291, E261, E303
+
+
 def version_callback(value: bool) -> None:
     """Get the installed gmnn-jax version."""
     if value:
+        console.print(logo)
         console.print(f"gmnn-jax {importlib.metadata.version('gmnn-jax')}")
         raise typer.Exit()
 


### PR DESCRIPTION
This PR adds a sub-command to the cli
`gmnn validate train/md <PATH>`

simply load the config file and parse it with the respective config class.

This is a convenient sanity check before submitting a job on a cluster.

I have also added a little logo to the version callback.