### PR TITLE
Allowing for variable number of NN layers in GMNN.

### DIFF
--- a/gmnn_jax/model/gmnn.py
+++ b/gmnn_jax/model/gmnn.py
@@ -57,8 +57,7 @@ class GMNN(hk.Module):
             dense.append(NTKLinear(n_hidden, b_init=b_init, name=f"dense_{ii}"))
             if ii < len(units) - 1:
                 dense.append(swish)
-        self.dense = hk.Sequential(dense)
-
+        self.readout = hk.Sequential(dense, name="readout")
 
         self.scale_shift = PerElementScaleShift(
             scale=elemental_energies_std,
@@ -69,7 +68,7 @@ class GMNN(hk.Module):
 
     def __call__(self, R: Array, Z: Array, neighbor: partition.NeighborList) -> Array:
         gm = self.descriptor(R, Z, neighbor)
-        h = jax.vmap(self.dense)(gm)
+        h = jax.vmap(self.readout)(gm)
         output = self.scale_shift(h, Z)
 
         return output
@@ -85,7 +84,7 @@ def get_md_model(
     n_radial: int = 5,
     dr_threshold: float = 0.5,
     nl_format: partition.NeighborListFormat = partition.Sparse,
-    **neighbor_kwargs
+    **neighbor_kwargs,
 ) -> MDModel:
     neighbor_fn = partition.neighbor_list(
         displacement,
@@ -94,7 +93,7 @@ def get_md_model(
         dr_threshold,
         fractional_coordinates=False,
         format=nl_format,
-        **neighbor_kwargs
+        **neighbor_kwargs,
     )
 
     n_atoms = atomic_numbers.shape[0]


### PR DESCRIPTION
This PR makes possible to use a different number of NN layers than 2. 
Closes #24 

heads up @PythonFZ, this is a breaking change and you won't be able to load old models without reformatting the checkpoints.