### PR TITLE
Switched MD from running for `n_steps` to a `duration` in fs

### DIFF
--- a/gmnn_jax/config/md_config.py
+++ b/gmnn_jax/config/md_config.py
@@ -12,10 +12,9 @@ class MDConfig(BaseModel, frozen=True, extra=Extra.forbid):
     seed: Random seed for momentum initialization.
     temperature: Temperature of the simulation in Kelvin.
     dt: Time step in fs.
-    n_steps: Total number of simulation steps. Will be replaced with
-        simulation time in the future.
+    duration: Total simulation time in fs.
     n_inner: Number of compiled simulation steps (i.e. number of iterations of the
-        `jax.lax.fori_loop` loop). Currently also determines sampling interval.
+        `jax.lax.fori_loop` loop). Also determines sampling interval.
     dr_threshold: Skin of the neighborlist.
     extra_capacity: JaxMD allocates a maximal number of neighbors.
         This argument lets you add additional capacity to avoid recompilation.
@@ -32,7 +31,7 @@ class MDConfig(BaseModel, frozen=True, extra=Extra.forbid):
 
     temperature: PositiveFloat
     dt: PositiveFloat = 0.5
-    n_steps: PositiveInt
+    duration: PositiveFloat
     n_inner: PositiveInt = 4
     dr_threshold: PositiveFloat = 0.5
     extra_capacity: PositiveInt = 0

--- a/tests/integration_tests/md/md_config.yaml
+++ b/tests/integration_tests/md/md_config.yaml
@@ -1,3 +1,3 @@
 temperature: 100
-n_steps: 4
+duration: 2.0
 n_inner: 2

--- a/tests/integration_tests/md/test_md.py
+++ b/tests/integration_tests/md/test_md.py
@@ -84,8 +84,7 @@ def test_run_md(get_tmp_path):
     run_md(model_config_dict, md_config_dict)
 
     traj = read(md_config.sim_dir + "/" + md_config.traj_name, index=":")
-    n_outer = int(md_config.n_steps // md_config.n_inner)
-    assert len(traj) == n_outer + 1
+    assert len(traj) == 3  # inital + 4 steps/ 2 inner steps
 
 
 def test_ase_calc(get_tmp_path):


### PR DESCRIPTION
The sim duration is now specified in fs instead of steps. `n_inner` remains equal to the sampling interval. Also fixed the number of steps that are run to be rounded up.