### PR TITLE
Allow 0 weights in los config for grid searches

### DIFF
--- a/gmnn_jax/config/train_config.py
+++ b/gmnn_jax/config/train_config.py
@@ -2,7 +2,7 @@ import os
 from typing import List, Literal, Optional
 
 import yaml
-from pydantic import BaseModel, Extra, PositiveFloat, PositiveInt
+from pydantic import BaseModel, Extra, NonNegativeFloat, PositiveFloat, PositiveInt
 
 
 class DataConfig(BaseModel):
@@ -45,7 +45,7 @@ class DataConfig(BaseModel):
     valid_batch_size: PositiveInt = 100
     shuffle_buffer_size: PositiveInt = 1000
 
-    energy_regularisation: PositiveFloat = 1.0
+    energy_regularisation: NonNegativeFloat = 1.0
 
 
 class ModelConfig(BaseModel, extra=Extra.forbid):
@@ -65,7 +65,7 @@ class ModelConfig(BaseModel, extra=Extra.forbid):
 
     n_basis: PositiveInt = 7
     n_radial: PositiveInt = 5
-    r_min: PositiveFloat = 0.5
+    r_min: NonNegativeFloat = 0.5
     r_max: PositiveFloat = 6.0
 
     nn: List[PositiveInt] = [512, 512]
@@ -142,7 +142,7 @@ class LossConfig(BaseModel, extra=Extra.forbid):
 
     name: str
     loss_type: str = "molecules"
-    weight: PositiveFloat = 1.0
+    weight: NonNegativeFloat = 1.0
 
 
 class CallbackConfig(BaseModel, frozen=True, extra=Extra.allow):


### PR DESCRIPTION
Changed loss weight, r_min and energy reg term to `NonNegativeFloat` in config.