### PR TITLE
Efficient Temperature and calculation of energy in JaxMD loop

### DIFF
--- a/apax/md/nvt.py
+++ b/apax/md/nvt.py
@@ -32,7 +32,7 @@ class TrajHandler:
         self.traj.write(new_atoms)
         self.async_manager = async_manager
 
-    def async_write(self, state, energy, step):
+    def write(self, state, energy, step):
         if np.any(np.isnan(state.position)):
             raise ValueError(
                 f"Simulation failed after {step} outer steps. Unable to"


### PR DESCRIPTION
This PR slightly improves the performance of the T calculation by moving it in the compiled inner loop.
Further, a call to the energy_fn was added after the loop to be able to collect the current potential energy since the NHC state does not contain it.

Closes #64 