### PR TITLE
moved TF and JAX config to train init

### DIFF
--- a/apax/__init__.py
+++ b/apax/__init__.py
@@ -1,9 +1,0 @@
-import warnings
-
-import tensorflow as tf
-from jax.config import config as jax_config
-
-tf.config.set_visible_devices([], "GPU")
-
-warnings.filterwarnings(action="ignore", category=FutureWarning, module=r"jax.*scatter")
-jax_config.update("jax_enable_x64", True)

--- a/apax/train/__init__.py
+++ b/apax/train/__init__.py
@@ -1,3 +1,14 @@
+import warnings
+
+import tensorflow as tf
+from jax.config import config as jax_config
+
+tf.config.set_visible_devices([], "GPU")
+
+warnings.filterwarnings(action="ignore", category=FutureWarning, module=r"jax.*scatter")
+jax_config.update("jax_enable_x64", True)
+
+
 from apax.train import checkpoints, eval, loss, metrics
 from apax.train.run import run
 from apax.train.trainer import fit


### PR DESCRIPTION
This PR moves the TF and JAX config to `apax.train.__init__` from `apax.__init__`.
The reason for this is that the CLI was horribly unresponsive due to the import of TF and jax in the root init.

However, I am not entirely sure this is the best solution for the config.
Thoughts? @Tetracarbonylnickel @PythonFZ 
