### PR TITLE
Different scaling and shifting schemes

### DIFF
--- a/apax/config/train_config.py
+++ b/apax/config/train_config.py
@@ -3,17 +3,17 @@ from typing import List, Literal, Optional
 
 import yaml
 from pydantic import (
-    BaseModel,
     BaseConfig,
+    BaseModel,
     Extra,
     NonNegativeFloat,
     PositiveFloat,
     PositiveInt,
+    create_model,
     root_validator,
-    create_model
 )
 
-from apax.data.statistics import shift_method_list, scale_method_list
+from apax.data.statistics import scale_method_list, shift_method_list
 
 
 class NoExtraConfig(BaseConfig):
@@ -94,14 +94,22 @@ class DataConfig(BaseModel, extra=Extra.forbid):
 
             # check if method exists
             if requested_method not in methods.keys():
-                raise KeyError(f"The initialization method '{requested_method}' is not among the implemented methods. Choose from {methods.keys()}")
+                raise KeyError(
+                    f"The initialization method '{requested_method}' is not among the"
+                    f" implemented methods. Choose from {methods.keys()}"
+                )
 
             # check if parameters names are complete and correct
             method = methods[requested_method]
-            fields = {name: (dtype, ...) for name, dtype in zip(method.parameters, method.dtypes)}
-            MethodConfig = create_model(f"{method.name}Config", __config__=NoExtraConfig, **fields)
+            fields = {
+                name: (dtype, ...)
+                for name, dtype in zip(method.parameters, method.dtypes)
+            }
+            MethodConfig = create_model(
+                f"{method.name}Config", __config__=NoExtraConfig, **fields
+            )
 
-            _ = MethodConfig(**requested_params)       
+            _ = MethodConfig(**requested_params)
 
         return values
 

--- a/apax/data/statistics.py
+++ b/apax/data/statistics.py
@@ -24,7 +24,7 @@ class PerElementRegressionShift:
     def compute(atoms_list, shift_options) -> np.ndarray:
         log.info("Computing per element energy regression.")
 
-        lambd=shift_options["energy_regularisation"]
+        lambd = shift_options["energy_regularisation"]
         energies = [atoms.get_potential_energy() for atoms in atoms_list]
         numbers = [atoms.numbers for atoms in atoms_list]
         system_sizes = [num.shape[0] for num in numbers]
@@ -61,13 +61,13 @@ class PerElementRegressionShift:
 class IsolatedAtomEnergyShift:
     name = "isolated_atom_energy_shift"
     parameters = ["E0s"]
-    dtypes = [dict[int: float]]
+    dtypes = [dict[int:float]]
 
     @staticmethod
     def compute(atoms_list, shift_options):
         n_species = 119
         elemental_energies_shift = np.zeros(n_species)
-        for k,v in shift_options.items():
+        for k, v in shift_options.items():
             elemental_energies_shift[k] = v
 
         return elemental_energies_shift
@@ -80,7 +80,6 @@ class MeanEnergyRMSScale:
 
     @staticmethod
     def compute(atoms_list, scale_options):
-
         # log.info("Computing per element energy regression.")
         energies = [atoms.get_potential_energy() for atoms in atoms_list]
         numbers = [atoms.numbers for atoms in atoms_list]
@@ -111,7 +110,7 @@ class PerElementForceRMSScale:
 
     @staticmethod
     def compute(atoms_list, scale_options):
-        n_species= 119
+        n_species = 119
 
         forces = np.concatenate([atoms.get_forces() for atoms in atoms_list], axis=0)
         numbers = np.concatenate([atoms.numbers for atoms in atoms_list], axis=0)
@@ -137,7 +136,7 @@ class GlobalCustomScale:
     def compute(atoms_list, scale_options):
         element_scale = scale_options["factor"]
         return element_scale
-    
+
 
 class PerElementCustomScale:
     name = "per_element_custom_scale"
@@ -148,35 +147,43 @@ class PerElementCustomScale:
     def compute(atoms_list, scale_options):
         n_species = 119
         element_scale = np.ones(n_species)
-        for k,v in scale_options["factors"].items():
+        for k, v in scale_options["factors"].items():
             element_scale[k] = v
 
         return element_scale
 
 
 shift_method_list = [PerElementRegressionShift, IsolatedAtomEnergyShift]
-scale_method_list = [MeanEnergyRMSScale, PerElementForceRMSScale, GlobalCustomScale, PerElementCustomScale]
+scale_method_list = [
+    MeanEnergyRMSScale,
+    PerElementForceRMSScale,
+    GlobalCustomScale,
+    PerElementCustomScale,
+]
 
 
-def compute_scale_shift_parameters(train_atoms_list, shift_method, scale_method, shift_options, scale_options):
-
+def compute_scale_shift_parameters(
+    train_atoms_list, shift_method, scale_method, shift_options, scale_options
+):
     shift_methods = {method.name: method for method in shift_method_list}
     scale_methods = {method.name: method for method in scale_method_list}
-    
+
     if shift_method not in shift_methods.keys():
-        raise KeyError(f"The shift method '{shift_method}' is not among the implemented methods. Choose from {shift_method.keys()}")
+        raise KeyError(
+            f"The shift method '{shift_method}' is not among the implemented methods."
+            f" Choose from {shift_method.keys()}"
+        )
     if scale_method not in scale_methods.keys():
-        raise KeyError(f"The scale method '{scale_method}' is not among the implemented methods. Choose from {scale_method.keys()}")
+        raise KeyError(
+            f"The scale method '{scale_method}' is not among the implemented methods."
+            f" Choose from {scale_method.keys()}"
+        )
 
     shift_method = shift_methods[shift_method]
     scale_method = scale_methods[scale_method]
 
-    shift_parameters = shift_method.compute(
-        train_atoms_list, shift_options
-    )
-    scale_parameters = scale_method.compute(
-        train_atoms_list, scale_options
-    )
+    shift_parameters = shift_method.compute(train_atoms_list, shift_options)
+    scale_parameters = scale_method.compute(train_atoms_list, scale_options)
 
     ds_stats = DatasetStats(shift_parameters, scale_parameters)
     return ds_stats

--- a/apax/train/eval.py
+++ b/apax/train/eval.py
@@ -79,7 +79,9 @@ def initialize_test_dataset(test_atoms_list, test_label_dict, config):
     shift_options = config.data.shift_options
     scale_options = config.data.scale_options
 
-    ds_stats = compute_scale_shift_parameters(test_atoms_list, shift_method, scale_method, shift_options, scale_options)
+    ds_stats = compute_scale_shift_parameters(
+        test_atoms_list, shift_method, scale_method, shift_options, scale_options
+    )
     displacement_fn, neighbor_fn = initialize_nbr_displacement_fns(
         atoms=test_atoms_list[0], cutoff=config.model.r_max
     )

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -89,7 +89,9 @@ def initialize_datasets(config, raw_datasets):
     shift_options = config.data.shift_options
     scale_options = config.data.scale_options
 
-    ds_stats = compute_scale_shift_parameters(train_atoms_list, shift_method, scale_method, shift_options, scale_options)
+    ds_stats = compute_scale_shift_parameters(
+        train_atoms_list, shift_method, scale_method, shift_options, scale_options
+    )
 
     displacement_fn, neighbor_fn = initialize_nbr_displacement_fns(
         train_atoms_list[0],

--- a/tests/unit_tests/data/test_statistics.py
+++ b/tests/unit_tests/data/test_statistics.py
@@ -20,7 +20,9 @@ def test_energy_per_element():
         energies.append(energy)
         atoms.calc = SinglePointCalculator(atoms, energy=energy)
 
-    elemental_shift = PerElementRegressionShift.compute(atoms_list, {"energy_regularisation": 0.0})
+    elemental_shift = PerElementRegressionShift.compute(
+        atoms_list, {"energy_regularisation": 0.0}
+    )
     regression_energies = []
     for atoms in atoms_list:
         energy = np.sum(elemental_shift[atoms.numbers])


### PR DESCRIPTION
This is a draft, as I am looking for feedback on the implementation.

I have separated shift and scaling methods.
We now have
- per element regression (as before)
- isolated atom reference shift
- mean energy RMSE scaling (as before)
- global scaling
- per element custom scaling
- per element force RMS scaling

shift and scale methods can be mixed and matched.
Further, all their parameters are dynamically validated. Each class implements a set of properties and corresponding dtypes they expects and then a pydantic Model is created based on this specification. This allows us to validate parameterized types like `dict[int, float]`.

