### PR TITLE
fixed NL overflow using wrong neighbors

### DIFF
--- a/apax/md/ase_calc.py
+++ b/apax/md/ase_calc.py
@@ -200,6 +200,7 @@ class ASECalculator(Calculator):
 
         if self.neighbors.did_buffer_overflow:
             print("neighbor list overflowed, reallocating.")
+            self.initialize(atoms)
             self.neighbors = self.neighbor_fn.allocate(positions)
             results, self.neighbors = self.step(positions, self.neighbors, box)
 


### PR DESCRIPTION
Hard to tell what the origin of the bug was, but we might as well reinitialize the model, it needs to be recompiled anyway when changing NL size