### PR TITLE
Vmap ensemble training and jaxmd inference

### DIFF
--- a/apax/bal/api.py
+++ b/apax/bal/api.py
@@ -83,7 +83,7 @@ def kernel_selection(
 
     n_train = len(train_atoms)
     dataset = initialize_dataset(
-        config, RawDataset(atoms_list=train_atoms + pool_atoms), False
+        config, RawDataset(atoms_list=train_atoms + pool_atoms), calc_stats=False
     )
     dataset.set_batch_size(processing_batch_size)
 

--- a/apax/bal/api.py
+++ b/apax/bal/api.py
@@ -82,7 +82,7 @@ def kernel_selection(
     config, params = restore_parameters(model_dir)
 
     n_train = len(train_atoms)
-    dataset = initialize_dataset(config, RawDataset(atoms_list=train_atoms + pool_atoms))
+    dataset = initialize_dataset(config, RawDataset(atoms_list=train_atoms + pool_atoms), False)
 
     init_box = dataset.init_input()["box"][0]
 

--- a/apax/bal/api.py
+++ b/apax/bal/api.py
@@ -82,7 +82,9 @@ def kernel_selection(
     config, params = restore_parameters(model_dir)
 
     n_train = len(train_atoms)
-    dataset = initialize_dataset(config, RawDataset(atoms_list=train_atoms + pool_atoms), False)
+    dataset = initialize_dataset(
+        config, RawDataset(atoms_list=train_atoms + pool_atoms), False
+    )
 
     init_box = dataset.init_input()["box"][0]
 

--- a/apax/config/train_config.py
+++ b/apax/config/train_config.py
@@ -292,6 +292,7 @@ class Config(BaseModel, frozen=True, extra="forbid"):
     n_epochs: PositiveInt
     patience: Optional[PositiveInt] = None
     seed: int = 1
+    n_models: int = 1
 
     data: DataConfig
     model: ModelConfig = ModelConfig()

--- a/apax/data/input_pipeline.py
+++ b/apax/data/input_pipeline.py
@@ -1,5 +1,7 @@
 import logging
 
+import jax
+import jax.numpy as jnp
 import numpy as np
 import tensorflow as tf
 
@@ -202,7 +204,17 @@ class TFPipeline:
             .take(1)
             .as_numpy_iterator()
         )
-        return inputs
+
+        inputs = jax.tree_map(lambda x: jnp.array(x[0]), inputs)
+        init_box = np.array(inputs["box"])
+        inputs = (
+            inputs["positions"],
+            inputs["numbers"],
+            inputs["idx"],
+            init_box,
+            inputs["offsets"],
+        )
+        return inputs, init_box
 
     def shuffle_and_batch(self):
         """Shuffles, batches, and pads the inputs/labels. This function prepares the

--- a/apax/data/statistics.py
+++ b/apax/data/statistics.py
@@ -61,7 +61,7 @@ class PerElementRegressionShift:
 class IsolatedAtomEnergyShift:
     name = "isolated_atom_energy_shift"
     parameters = ["E0s"]
-    dtypes = [dict[int,float]]
+    dtypes = [dict[int, float]]
 
     @staticmethod
     def compute(inputs, labels, shift_options):

--- a/apax/md/ase_calc.py
+++ b/apax/md/ase_calc.py
@@ -6,19 +6,16 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from ase.calculators.calculator import Calculator, all_changes
-from flax.traverse_util import flatten_dict
 from jax_md import partition, quantity, space
 from matscipy.neighbours import neighbour_list
 
 from apax.model import ModelBuilder
-from apax.train.checkpoints import restore_parameters
+from apax.train.checkpoints import check_for_ensemble, restore_parameters
 from apax.utils import jax_md_reduced
 
 
 def maybe_vmap(apply, params, Z):
-    flat_params = flatten_dict(params)
-    shapes = [v.shape[0] for v in flat_params.values()]
-    is_ensemble = shapes == shapes[::-1]
+    is_ensemble = check_for_ensemble(params)
 
     if is_ensemble:
         apply = jax.vmap(apply, in_axes=(0, None, None, None, None, None))

--- a/apax/md/nvt.py
+++ b/apax/md/nvt.py
@@ -25,6 +25,16 @@ from apax.utils import jax_md_reduced
 log = logging.getLogger(__name__)
 
 
+def make_energy_ensemble(model):
+    def ensemble(positions, Z, idx, box, offsets):
+        energies = model(positions, Z, idx, box, offsets)
+        energy = jnp.mean(energies)
+
+        return energy
+
+    return ensemble
+
+
 def heights_of_box_sides(box):
     heights = []
 
@@ -350,7 +360,7 @@ def md_setup(model_config: Config, md_config: MDConfig):
         model.apply,
         params,
         Z=system.atomic_numbers,
-        box=system.box,
+        box=system.box, # TODO IS THIS CORRECT FOR NPT???
         offsets=jnp.array([0.0, 0.0, 0.0]),
     )
     sim_fns = SimulationFunctions(energy_fn, shift_fn, neighbor_fn)

--- a/apax/md/nvt.py
+++ b/apax/md/nvt.py
@@ -19,31 +19,34 @@ from apax.config import Config, MDConfig, parse_config
 from apax.md.io import H5TrajHandler
 from apax.md.md_checkpoint import load_md_state
 from apax.model import ModelBuilder
-from apax.train.eval import load_params
+from apax.train.checkpoints import restore_parameters
 from apax.utils import jax_md_reduced
 
 log = logging.getLogger(__name__)
 
 
 def create_energy_fn(model, params, numbers, box, n_models):
-    def ensemble(positions, Z, idx, box, offsets):
-        energies = model(positions, Z, idx, box, offsets)
+    def ensemble(params, R, Z, neighbor, box, offsets):
+        vmodel = jax.vmap(model, (0, None, None, None, None, None), 0)
+        energies = vmodel(params, R, Z, neighbor, box, offsets)
         energy = jnp.mean(energies)
 
         return energy
 
     if n_models > 1:
-        model = ensemble
+        energy_fn = ensemble
+    else:
+        energy_fn = model
 
-    partial(
-        model,
+    energy_fn = partial(
+        energy_fn,
         params,
         Z=numbers,
         box=box,  # TODO IS THIS CORRECT FOR NPT???
         offsets=jnp.array([0.0, 0.0, 0.0]),
     )
 
-    return ensemble
+    return energy_fn
 
 
 def heights_of_box_sides(box):
@@ -366,7 +369,7 @@ def md_setup(model_config: Config, md_config: MDConfig):
         disable_cell_list=True,
     )
 
-    params = load_params(model_config.data.model_version_path())
+    _, params = restore_parameters(model_config.data.model_version_path())
     energy_fn = create_energy_fn(
         model.apply, params, system.atomic_numbers, system.box, model_config.n_models
     )

--- a/apax/md/nvt.py
+++ b/apax/md/nvt.py
@@ -26,14 +26,11 @@ log = logging.getLogger(__name__)
 
 
 def create_energy_fn(model, params, numbers, box, n_models):
-
-    
     def ensemble(positions, Z, idx, box, offsets):
         energies = model(positions, Z, idx, box, offsets)
         energy = jnp.mean(energies)
 
         return energy
-    
 
     if n_models > 1:
         model = ensemble
@@ -42,7 +39,7 @@ def create_energy_fn(model, params, numbers, box, n_models):
         model,
         params,
         Z=numbers,
-        box=box, # TODO IS THIS CORRECT FOR NPT???
+        box=box,  # TODO IS THIS CORRECT FOR NPT???
         offsets=jnp.array([0.0, 0.0, 0.0]),
     )
 
@@ -370,7 +367,9 @@ def md_setup(model_config: Config, md_config: MDConfig):
     )
 
     params = load_params(model_config.data.model_version_path())
-    energy_fn = create_energy_fn(model.apply, params, system.atomic_numbers, system.box, model_config.n_models)
+    energy_fn = create_energy_fn(
+        model.apply, params, system.atomic_numbers, system.box, model_config.n_models
+    )
     sim_fns = SimulationFunctions(energy_fn, shift_fn, neighbor_fn)
     return system, sim_fns
 

--- a/apax/train/checkpoints.py
+++ b/apax/train/checkpoints.py
@@ -31,7 +31,7 @@ def check_for_ensemble(params: FrozenDict) -> int:
 def create_train_state(model, params: FrozenDict, tx):
     n_models = check_for_ensemble(params)
 
-    def inner(params):
+    def create_single_train_state(params):
         state = train_state.TrainState.create(
             apply_fn=model,
             params=params,
@@ -40,9 +40,9 @@ def create_train_state(model, params: FrozenDict, tx):
         return state
 
     if n_models > 1:
-        inner = jax.vmap(inner, axis_name="ensemble")
+        create_single_train_state = jax.vmap(create_single_train_state, axis_name="ensemble")
 
-    return inner(params)
+    return create_single_train_state(params)
 
 
 def create_params(model, rng_key, sample_input: tuple, n_models: int):

--- a/apax/train/checkpoints.py
+++ b/apax/train/checkpoints.py
@@ -18,11 +18,15 @@ def check_for_ensemble(params):
     flat_params = flatten_dict(params)
     shapes = [v.shape[0] for v in flat_params.values()]
     is_ensemble = shapes == shapes[::-1]
-    return is_ensemble
+
+    if is_ensemble:
+        return shapes[0]
+    else:
+        return 1
 
 
 def create_train_state(model, params, tx):
-    is_ensemble = check_for_ensemble(params)
+    n_models = check_for_ensemble(params)
 
     def inner(params):
         state = train_state.TrainState.create(
@@ -32,7 +36,7 @@ def create_train_state(model, params, tx):
         )
         return state
 
-    if is_ensemble:
+    if n_models > 1:
         inner = jax.vmap(inner, axis_name="ensemble")
 
     return inner(params)

--- a/apax/train/checkpoints.py
+++ b/apax/train/checkpoints.py
@@ -14,10 +14,13 @@ from apax.config.train_config import Config
 log = logging.getLogger(__name__)
 
 
-def check_for_ensemble(params):
+def check_for_ensemble(params: FrozenDict) -> int:
+    """Checks if a set of parameters belongs to an ensemble model.
+    This is the case if all parameters share the same first dimension (parameter batch)
+    """
     flat_params = flatten_dict(params)
     shapes = [v.shape[0] for v in flat_params.values()]
-    is_ensemble = shapes == shapes[::-1]
+    is_ensemble = len(set(shapes)) == 1
 
     if is_ensemble:
         return shapes[0]
@@ -25,7 +28,7 @@ def check_for_ensemble(params):
         return 1
 
 
-def create_train_state(model, params, tx):
+def create_train_state(model, params: FrozenDict, tx):
     n_models = check_for_ensemble(params)
 
     def inner(params):

--- a/apax/train/checkpoints.py
+++ b/apax/train/checkpoints.py
@@ -40,9 +40,14 @@ def create_train_state(model, params: FrozenDict, tx):
         return state
 
     if n_models > 1:
-        create_single_train_state = jax.vmap(create_single_train_state, axis_name="ensemble")
+        train_state_fn = jax.vmap(
+            create_single_train_state,
+            axis_name="ensemble"
+        )
+    else:
+        train_state_fn = create_single_train_state
 
-    return create_single_train_state(params)
+    return train_state_fn(params)
 
 
 def create_params(model, rng_key, sample_input: tuple, n_models: int):

--- a/apax/train/checkpoints.py
+++ b/apax/train/checkpoints.py
@@ -46,6 +46,8 @@ def create_params(model, rng_key, sample_input: tuple, n_models: int):
     keys = jax.random.split(rng_key, num=n_models + 1)
     rng_key, model_rng = keys[0], keys[1:]
 
+    log.info(f"initializing {n_models} models")
+
     if n_models == 1:
         params = model.init(model_rng[0], *sample_input)
     elif n_models > 1:

--- a/apax/train/checkpoints.py
+++ b/apax/train/checkpoints.py
@@ -55,6 +55,7 @@ def create_params(model, rng_key, sample_input: tuple, n_models: int):
         params = model.init(model_rng[0], *sample_input)
     elif n_models > 1:
         num_args = len(sample_input)
+        # vmap only over parameters, not over any data from the input
         in_axes = (0, *[None] * num_args)
         params = jax.vmap(model.init, in_axes=in_axes)(model_rng, *sample_input)
     else:

--- a/apax/train/checkpoints.py
+++ b/apax/train/checkpoints.py
@@ -47,7 +47,7 @@ def create_params(model, rng_key, sample_input: tuple, n_models: int):
     rng_key, model_rng = keys[0], keys[1:]
 
     if n_models == 1:
-        params = model.init(model_rng, *sample_input)
+        params = model.init(model_rng[0], *sample_input)
     elif n_models > 1:
         num_args = len(sample_input)
         in_axes = (0, *[None] * num_args)

--- a/apax/train/eval.py
+++ b/apax/train/eval.py
@@ -74,7 +74,9 @@ def load_test_data(
 
 def predict(model, params, Metrics, loss_fn, test_ds, callbacks, is_ensemble=False):
     callbacks.on_train_begin()
-    _, test_step_fn = make_step_fns(loss_fn, Metrics, model=model, sam_rho=0.0, is_ensemble=is_ensemble)
+    _, test_step_fn = make_step_fns(
+        loss_fn, Metrics, model=model, sam_rho=0.0, is_ensemble=is_ensemble
+    )
 
     test_steps_per_epoch = test_ds.steps_per_epoch()
     batch_test_ds = test_ds.shuffle_and_batch()
@@ -143,4 +145,12 @@ def eval_model(config_path, n_test=-1, log_file="eval.log", log_level="error"):
 
     config, params = restore_single_parameters(model_version_path)
 
-    predict(model, params, Metrics, loss_fn, test_ds, callbacks, is_ensemble= config.n_models > 1)
+    predict(
+        model,
+        params,
+        Metrics,
+        loss_fn,
+        test_ds,
+        callbacks,
+        is_ensemble=config.n_models > 1,
+    )

--- a/apax/train/eval.py
+++ b/apax/train/eval.py
@@ -93,7 +93,7 @@ def predict(model, params, Metrics, loss_fn, test_ds, callbacks, is_ensemble=Fal
     for batch_idx in range(test_steps_per_epoch):
         inputs, labels = next(batch_test_ds)
 
-        test_metrics, batch_loss = test_step_fn(params, inputs, labels, test_metrics)
+        batch_loss, test_metrics = test_step_fn(params, inputs, labels, test_metrics)
 
         epoch_loss["test_loss"] += batch_loss
         batch_pbar.set_postfix(test_loss=epoch_loss["test_loss"] / batch_idx)

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -55,7 +55,7 @@ def run(user_config, log_file="train.log", log_level="error"):
     directory = Path(config.data.directory)
     model_version_path = directory / experiment
     log.info("Initializing directories")
-    model_version_path.mkdir(exist_ok=True)
+    model_version_path.mkdir(parents=True, exist_ok=True)
     config.dump_config(model_version_path)
 
     callbacks = initialize_callbacks(config.callbacks, model_version_path)
@@ -67,7 +67,7 @@ def run(user_config, log_file="train.log", log_level="error"):
     val_ds = initialize_dataset(config, val_raw_ds, calc_stats=False)
 
     train_ds.set_batch_size(config.data.batch_size)
-    val_ds.set_batch_size(config.data.val_batch_size)
+    val_ds.set_batch_size(config.data.valid_batch_size)
 
     log.info("Initializing Model")
     sample_input, init_box = train_ds.init_input()

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from typing import List
 
 import jax
-import numpy as np
 
 from apax.config import LossConfig, parse_config
 from apax.data.initialization import initialize_dataset, load_data_files

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -254,9 +254,6 @@ def run(user_config, log_file="train.log", log_level="error"):
         )
         state.replace(params=params)
 
-    # TODO
-    # enable param loading in ASE calc and usage in jaxmd
-
     fit(
         state,
         train_ds,

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -260,6 +260,12 @@ def run(user_config, log_file="train.log", log_level="error"):
         transition_steps=transition_steps,
         **config.optimizer.model_dump(),
     )
+    # TODO
+    # vmap params and apply fn
+    # multiply batches
+    # split step fns into loss/param update computetion and metric accumulation.
+    # We need to update the former but not the latter
+    # make sure that checkpoint loading and model senemble in calculator work
 
     fit(
         batched_model,

--- a/apax/train/trainer.py
+++ b/apax/train/trainer.py
@@ -159,6 +159,7 @@ def calc_loss(params, inputs, labels, loss_fn, model):
 
 
 def make_ensemble_update(update_fn: Callable) -> Callable:
+    # vmap over train state
     v_update_fn = jax.vmap(update_fn, (0, None, None), (0, 0, 0))
 
     def ensemble_update_fn(state, inputs, labels):
@@ -166,13 +167,14 @@ def make_ensemble_update(update_fn: Callable) -> Callable:
 
         mean_predictions = jax.tree_map(lambda x: jnp.mean(x, axis=0), predictions)
         mean_loss = jnp.mean(loss)
-        # TODO Add std to predictions
+        # Should we add std to predictions?
         return mean_loss, mean_predictions, state
 
     return ensemble_update_fn
 
 
 def make_ensemble_eval(update_fn: Callable) -> Callable:
+    # vmap over train state
     v_update_fn = jax.vmap(update_fn, (0, None, None), (0, 0))
 
     def ensemble_eval_fn(state, inputs, labels):

--- a/apax/train/trainer.py
+++ b/apax/train/trainer.py
@@ -227,7 +227,7 @@ def make_step_fns(loss_fn, Metrics, model, sam_rho, is_ensemble):
 
     @jax.jit
     def val_step(params, inputs, labels, batch_metrics):
-        predictions, loss = eval_fn(params, inputs, labels)
+        loss, predictions = eval_fn(params, inputs, labels)
 
         new_batch_metrics = Metrics.single_from_model_output(
             label=labels, prediction=predictions

--- a/apax/train/trainer.py
+++ b/apax/train/trainer.py
@@ -160,9 +160,7 @@ def calc_loss(params, inputs, labels, loss_fn, model):
 
 
 def make_ensemble_update(update_fn: Callable) -> Callable:
-    v_update_fn = jax.vmap(
-        update_fn, (0, None, None), (0, 0, 0)
-    )
+    v_update_fn = jax.vmap(update_fn, (0, None, None), (0, 0, 0))
 
     def ensemble_update_fn(state, inputs, labels):
         predictions, loss, state = v_update_fn(state, inputs, labels)

--- a/tests/integration_tests/md/test_md.py
+++ b/tests/integration_tests/md/test_md.py
@@ -34,6 +34,8 @@ def test_run_md(get_tmp_path):
     md_config_dict["initial_structure"] = get_tmp_path.as_posix() + "/atoms.extxyz"
 
     model_config = Config.model_validate(model_config_dict)
+    os.makedirs(model_config.data.model_version_path())
+    model_config.dump_config(model_config.data.model_version_path())
     md_config = MDConfig.model_validate(md_config_dict)
 
     positions = jnp.array(


### PR DESCRIPTION
This PR implements the vmapped training of multiple models at once.
These models can be loaded into the ASE calc for ensembling similarly to training multiple models separately. 
Furthermore, ensembles can now be used in jaxmd.
However, uncertainties are not logged yet. 