### PR TITLE
Val bs fix and distance computation refactor

### DIFF
--- a/apax/bal/api.py
+++ b/apax/bal/api.py
@@ -8,7 +8,7 @@ from click import Path
 from tqdm import trange
 
 from apax.bal import feature_maps, kernel, selection, transforms
-from apax.data.input_pipeline import TFPipeline
+from apax.data.input_pipeline import AtomisticDataset
 from apax.model.builder import ModelBuilder
 from apax.model.gmnn import EnergyModel
 from apax.train.checkpoints import restore_parameters
@@ -43,11 +43,11 @@ def create_feature_fn(
     return feature_fn
 
 
-def compute_features(feature_fn, dataset: TFPipeline, processing_batch_size: int):
+def compute_features(feature_fn, dataset: AtomisticDataset):
     """Compute the features of a dataset."""
     features = []
     n_data = dataset.n_data
-    ds = dataset.batch(processing_batch_size)
+    ds = dataset.batch()
 
     pbar = trange(n_data, desc="Computing features", ncols=100, leave=True)
     for i, (inputs, _) in enumerate(ds):
@@ -83,6 +83,7 @@ def kernel_selection(
 
     n_train = len(train_atoms)
     dataset = initialize_dataset(config, RawDataset(atoms_list=train_atoms + pool_atoms))
+    dataset.set_batch_size(processing_batch_size)
 
     init_box = dataset.init_input()["box"][0]
 
@@ -92,7 +93,7 @@ def kernel_selection(
     feature_fn = create_feature_fn(
         model, params, base_feature_map, feature_transforms, is_ensemble
     )
-    g = compute_features(feature_fn, dataset, processing_batch_size)
+    g = compute_features(feature_fn, dataset)
     km = kernel.KernelMatrix(g, n_train)
     new_indices = selection_fn(km, selection_batch_size)
 

--- a/apax/bal/feature_maps.py
+++ b/apax/bal/feature_maps.py
@@ -1,4 +1,4 @@
-from typing import Literal, Union
+from typing import Literal, Tuple, Union
 
 import jax
 import jax.numpy as jnp

--- a/apax/bal/feature_maps.py
+++ b/apax/bal/feature_maps.py
@@ -1,4 +1,4 @@
-from typing import Literal, Tuple, Union
+from typing import Literal, Union
 
 import jax
 import jax.numpy as jnp
@@ -6,7 +6,7 @@ from flax.traverse_util import flatten_dict, unflatten_dict
 from pydantic import BaseModel, TypeAdapter
 
 
-def extract_feature_params(params: dict, layer_name: str) -> Tuple[dict, dict]:
+def extract_feature_params(params: dict, layer_name: str) -> tuple[dict, dict]:
     """Seprate params into those belonging to a selected layer
     and the remaining ones.
     """

--- a/apax/cli/templates/train_config_full.yaml
+++ b/apax/cli/templates/train_config_full.yaml
@@ -79,5 +79,3 @@ checkpoints:
 progress_bar:
   disable_epoch_pbar: false
   disable_nl_pbar: false
-
-maximize_l2_cache: true

--- a/apax/config/train_config.py
+++ b/apax/config/train_config.py
@@ -286,7 +286,6 @@ class Config(BaseModel, frozen=True, extra="forbid"):
     callbacks: List of :class: `callback` <config.CallbackConfig> configurations.
     progress_bar: Progressbar configuration.
     checkpoints: Checkpoint configuration.
-    maximize_l2_cache: Whether or not to maximize GPU L2 cache.
     """
 
     n_epochs: PositiveInt
@@ -301,7 +300,6 @@ class Config(BaseModel, frozen=True, extra="forbid"):
     callbacks: List[CallbackConfig] = [CallbackConfig(name="csv")]
     progress_bar: TrainProgressbarConfig = TrainProgressbarConfig()
     checkpoints: CheckpointConfig = CheckpointConfig()
-    maximize_l2_cache: bool = False
 
     def dump_config(self, save_path):
         """

--- a/apax/data/initialization.py
+++ b/apax/data/initialization.py
@@ -1,0 +1,86 @@
+import logging
+import dataclasses
+from typing import Optional
+import os
+
+import numpy as np
+from ase import Atoms
+
+from apax.data.input_pipeline import AtomisticDataset, create_dict_dataset
+from apax.data.statistics import compute_scale_shift_parameters
+from apax.utils.data import load_data, split_atoms, split_idxs, split_label
+
+log = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class RawDataset:
+    atoms_list: list[Atoms]
+    additional_labels: Optional[dict] = None
+
+
+def load_data_files(data_config, model_version_path):
+    log.info("Running Input Pipeline")
+    if data_config.data_path is not None:
+        log.info(f"Read data file {data_config.data_path}")
+        atoms_list, label_dict = load_data(data_config.data_path)
+
+        train_idxs, val_idxs = split_idxs(
+            atoms_list, data_config.n_train, data_config.n_valid
+        )
+        train_atoms_list, val_atoms_list = split_atoms(atoms_list, train_idxs, val_idxs)
+        train_label_dict, val_label_dict = split_label(label_dict, train_idxs, val_idxs)
+
+        np.savez(
+            os.path.join(model_version_path, "train_val_idxs"),
+            train_idxs=train_idxs,
+            val_idxs=val_idxs,
+        )
+
+    elif data_config.train_data_path and data_config.val_data_path is not None:
+        log.info(f"Read training data file {data_config.train_data_path}")
+        log.info(f"Read validation data file {data_config.val_data_path}")
+        train_atoms_list, train_label_dict = load_data(data_config.train_data_path)
+        val_atoms_list, val_label_dict = load_data(data_config.val_data_path)
+    else:
+        raise ValueError("input data path/paths not defined")
+
+    train_raw_ds = RawDataset(
+        atoms_list=train_atoms_list, additional_labels=train_label_dict
+    )
+    val_raw_ds = RawDataset(atoms_list=val_atoms_list, additional_labels=val_label_dict)
+
+    return train_raw_ds, val_raw_ds
+
+
+def initialize_dataset(config, raw_ds, calc_stats: bool = True):
+    inputs, labels = create_dict_dataset(
+        raw_ds.atoms_list,
+        r_max=config.model.r_max,
+        external_labels=raw_ds.additional_labels,
+        disable_pbar=config.progress_bar.disable_nl_pbar,
+        pos_unit=config.data.pos_unit,
+        energy_unit=config.data.energy_unit,
+    )
+
+    if calc_stats:
+        ds_stats = compute_scale_shift_parameters(
+            inputs,
+            labels,
+            config.data.shift_method,
+            config.data.scale_method,
+            config.data.shift_options,
+            config.data.scale_options,
+        )
+
+    dataset = AtomisticDataset(
+        inputs,
+        labels,
+        config.n_epochs,
+        buffer_size=config.data.shuffle_buffer_size,
+    )
+
+    if calc_stats:
+        return dataset, ds_stats
+    else:
+        return dataset

--- a/apax/data/initialization.py
+++ b/apax/data/initialization.py
@@ -1,7 +1,7 @@
-import logging
 import dataclasses
-from typing import Optional
+import logging
 import os
+from typing import Optional
 
 import numpy as np
 from ase import Atoms

--- a/apax/data/input_pipeline.py
+++ b/apax/data/input_pipeline.py
@@ -11,7 +11,7 @@ from apax.utils.convert import atoms_to_arrays
 log = logging.getLogger(__name__)
 
 
-def find_largest_system(inputs: dict[np.ndarray]) -> tuple[int]:
+def find_largest_system(inputs: dict[str, np.ndarray]) -> tuple[int]:
     max_atoms = np.max(inputs["fixed"]["n_atoms"])
     nbr_shapes = [idx.shape[1] for idx in inputs["ragged"]["idx"]]
     max_nbrs = np.max(nbr_shapes)

--- a/apax/data/input_pipeline.py
+++ b/apax/data/input_pipeline.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Dict, Iterator
 
+import jax
 import numpy as np
 import tensorflow as tf
-import jax
 
 from apax.data.preprocessing import dataset_neighborlist, prefetch_to_single_device
 from apax.utils.convert import atoms_to_arrays
@@ -117,7 +117,9 @@ def create_dict_dataset(
     return inputs, labels
 
 
-def dataset_from_dicts(inputs: Dict[str, np.ndarray], labels: Dict[str, np.ndarray]) -> tf.data.Dataset:
+def dataset_from_dicts(
+    inputs: Dict[str, np.ndarray], labels: Dict[str, np.ndarray]
+) -> tf.data.Dataset:
     # tf.RaggedTensors should be created from `tf.ragged.stack`
     # instead of `tf.ragged.constant` for performance reasons.
     # See https://github.com/tensorflow/tensorflow/issues/47853
@@ -183,11 +185,11 @@ class AtomisticDataset:
 
     def set_batch_size(self, batch_size: int):
         self.batch_size = self.validate_batch_size(batch_size)
-    
+
     def _check_batch_size(self):
         if self.batch_size is None:
             raise ValueError("Dataset Batch Size has not been set yet")
-    
+
     def validate_batch_size(self, batch_size: int) -> int:
         if batch_size > self.n_data:
             msg = (
@@ -226,7 +228,7 @@ class AtomisticDataset:
         shuffled_ds :
             Iterator that returns inputs and labels of one batch in each step.
         """
-        self._check_batch_size()  
+        self._check_batch_size()
         shuffled_ds = (
             self.ds.shuffle(buffer_size=self.buffer_size)
             .repeat(self.n_epoch)

--- a/apax/data/preprocessing.py
+++ b/apax/data/preprocessing.py
@@ -1,6 +1,8 @@
 import collections
 import itertools
 import logging
+from typing import Callable
+from ase import Atoms
 
 import jax
 import jax.numpy as jnp
@@ -14,7 +16,7 @@ from apax.utils import jax_md_reduced
 log = logging.getLogger(__name__)
 
 
-def initialize_nbr_fn(atoms, cutoff):
+def initialize_nbr_fn(atoms: Atoms, cutoff: float) -> Callable:
     neighbor_fn = None
     default_box = 100
     box = jnp.asarray(atoms.cell.array)
@@ -114,7 +116,7 @@ def dataset_neighborlist(
     return idx_list, offset_list
 
 
-def prefetch_to_single_device(iterator, size):
+def prefetch_to_single_device(iterator, size: int):
     """
     inspired by
     https://flax.readthedocs.io/en/latest/_modules/flax/jax_utils.html#prefetch_to_device

--- a/apax/data/preprocessing.py
+++ b/apax/data/preprocessing.py
@@ -2,11 +2,11 @@ import collections
 import itertools
 import logging
 from typing import Callable
-from ase import Atoms
 
 import jax
 import jax.numpy as jnp
 import numpy as np
+from ase import Atoms
 from jax_md import partition, space
 from matscipy.neighbours import neighbour_list
 from tqdm import trange
@@ -104,7 +104,9 @@ def dataset_neighborlist(
             n_neighbors = neighbor_idxs.shape[1]
             offsets = np.full([n_neighbors, 3], 0)
         else:
-            idxs_i, idxs_j, offsets = neighbour_list("ijS", atoms_list[i], r_max) # TODO replace atoms list with positions and box
+            idxs_i, idxs_j, offsets = neighbour_list(
+                "ijS", atoms_list[i], r_max
+            )  # TODO replace atoms list with positions and box
             offsets = np.matmul(offsets, box[i])
             neighbor_idxs = np.array([idxs_i, idxs_j], dtype=np.int32)
 

--- a/apax/data/preprocessing.py
+++ b/apax/data/preprocessing.py
@@ -116,18 +116,6 @@ def get_shrink_wrapped_cell(positions):
     return cell, cell_origin
 
 
-def get_shrink_wrapped_cell(positions):
-    rmin = np.min(positions, axis=0)
-    rmax = np.max(positions, axis=0)
-    cell_origin = rmin
-    cell = np.diag(rmax - rmin)
-    for idx in range(3):
-        if np.all(cell[:, idx] < 10e-3):
-            cell[idx, idx] = 1.0
-
-    return cell, cell_origin
-
-
 def prefetch_to_single_device(iterator, size: int):
     """
     inspired by

--- a/apax/data/statistics.py
+++ b/apax/data/statistics.py
@@ -10,9 +10,7 @@ log = logging.getLogger(__name__)
 class DatasetStats:
     elemental_shift: np.array = None
     elemental_scale: float = None
-    n_atoms: int = 0
     n_species: int = 119
-    displacement_fn = None
 
 
 class PerElementRegressionShift:
@@ -36,7 +34,7 @@ class PerElementRegressionShift:
         n_atoms_total = np.sum(system_sizes)
 
         mean_energy = ds_energy / n_atoms_total
-        n_species = 119  # max([max(n) for n in numbers]) + 1
+        n_species = 119
         X = np.zeros(shape=(energies.shape[0], n_species))
         y = np.zeros(energies.shape[0])
 

--- a/apax/data/statistics.py
+++ b/apax/data/statistics.py
@@ -34,7 +34,7 @@ class PerElementRegressionShift:
         n_atoms_total = np.sum(system_sizes)
 
         mean_energy = ds_energy / n_atoms_total
-        n_species = 119
+        n_species = 119  # for simplicity, we assume any element could be in the dataset
         X = np.zeros(shape=(energies.shape[0], n_species))
         y = np.zeros(energies.shape[0])
 

--- a/apax/layers/descriptor/gaussian_moment_descriptor.py
+++ b/apax/layers/descriptor/gaussian_moment_descriptor.py
@@ -15,80 +15,29 @@ from apax.layers.descriptor.triangular_indices import tril_2d_indices, tril_3d_i
 from apax.layers.masking import mask_by_neighbor
 
 
-def disp_fn(ri, rj, perturbation, box):
-    dR = pairwise_displacement(ri, rj)
-    dR = transform(box, dR)
-
-    if perturbation is not None:
-        dR = dR + raw_transform(perturbation, dR)
-        # https://github.com/mir-group/nequip/blob/c56f48fcc9b4018a84e1ed28f762fadd5bc763f1/nequip/nn/_grad_output.py#L267
-        # https://github.com/sirmarcel/glp/blob/main/glp/calculators/utils.py
-        # other codes do R = R + strain, not dR
-        # can be implemented for efficiency
-
-    return dR
-
-
-def get_disp_fn(displacement):
-    def disp_fn(ri, rj, perturbation, box):
-        return displacement(ri, rj, perturbation, box=box)
-
-    return disp_fn
-
-
 class GaussianMomentDescriptor(nn.Module):
     radial_fn: nn.Module = RadialFunction()
     n_contr: int = 8
     dtype: Any = jnp.float32
     apply_mask: bool = True
-    init_box: np.array = field(default_factory=lambda: np.array([0.0, 0.0, 0.0]))
-    inference_disp_fn: Any = None
 
     def setup(self):
         self.r_max = self.radial_fn.r_max
         self.n_radial = self.radial_fn._n_radial
-
-        if np.all(self.init_box < 1e-6):
-            # displacement function for gas phase training and predicting
-            displacement_fn = space.free()[0]
-            self.displacement = space.map_bond(displacement_fn)
-        elif self.inference_disp_fn is None:
-            # displacement function used for training on periodic systems
-            self.displacement = vmap(disp_fn, (0, 0, None, None), 0)
-        else:
-            mappable_displacement_fn = get_disp_fn(self.inference_disp_fn)
-            self.displacement = vmap(mappable_displacement_fn, (0, 0, None, None), 0)
 
         self.distance = vmap(space.distance, 0, 0)
 
         self.triang_idxs_2d = tril_2d_indices(self.n_radial)
         self.triang_idxs_3d = tril_3d_indices(self.n_radial)
 
-    def __call__(
-        self, R, Z, neighbor_idxs, box, offsets=np.full([3, 3], 0), perturbation=None
-    ):
-        R = R.astype(jnp.float64)
-        # R shape n_atoms x 3
+    def __call__(self, dr_vec, Z, neighbor_idxs):
         # Z shape n_atoms
-        n_atoms = R.shape[0]
+        n_atoms = Z.shape[0]
 
         idx_i, idx_j = neighbor_idxs[0], neighbor_idxs[1]
 
         # shape: neighbors
         Z_i, Z_j = Z[idx_i, ...], Z[idx_j, ...]
-
-        Ri = R[idx_i]
-        Rj = R[idx_j]
-
-        # dr_vec shape: neighbors x 3
-        if np.all(self.init_box < 1e-6):
-            # reverse conventnion to match TF
-            # distance vector for gas phase training and predicting
-            dr_vec = self.displacement(Rj, Ri).astype(self.dtype)
-        else:
-            # distance vector for training on periodic systems
-            dr_vec = self.displacement(Rj, Ri, perturbation, box).astype(self.dtype)
-            dr_vec += offsets.astype(self.dtype)
 
         # dr shape: neighbors
         dr = self.distance(dr_vec).astype(self.dtype)
@@ -105,19 +54,13 @@ class GaussianMomentDescriptor(nn.Module):
         moments = geometric_moments(radial_function, dn, idx_j, n_atoms)
 
         contr_0 = moments[0]
-        contr_1 = jnp.einsum("ari, asi -> rsa", moments[1], moments[1])
-        contr_2 = jnp.einsum("arij, asij -> rsa", moments[2], moments[2])
-        contr_3 = jnp.einsum("arijk, asijk -> rsa", moments[3], moments[3])
-        contr_4 = jnp.einsum(
-            "arij, asik, atjk -> rsta", moments[2], moments[2], moments[2]
-        )
-        contr_5 = jnp.einsum("ari, asj, atij -> rsta", moments[1], moments[1], moments[2])
-        contr_6 = jnp.einsum(
-            "arijk, asijl, atkl -> rsta", moments[3], moments[3], moments[2]
-        )
-        contr_7 = jnp.einsum(
-            "arijk, asij, atk -> rsta", moments[3], moments[2], moments[1]
-        )
+        contr_1 = jnp.einsum("ari, asi -> rsa", moments[1], moments[1])                         # noqa: E501
+        contr_2 = jnp.einsum("arij, asij -> rsa", moments[2], moments[2])                       # noqa: E501
+        contr_3 = jnp.einsum("arijk, asijk -> rsa", moments[3], moments[3])                     # noqa: E501
+        contr_4 = jnp.einsum("arij, asik, atjk -> rsta", moments[2], moments[2], moments[2])    # noqa: E501
+        contr_5 = jnp.einsum("ari, asj, atij -> rsta", moments[1], moments[1], moments[2])      # noqa: E501
+        contr_6 = jnp.einsum("arijk, asijl, atkl -> rsta", moments[3], moments[3], moments[2])  # noqa: E501
+        contr_7 = jnp.einsum("arijk, asij, atk -> rsta", moments[3], moments[2], moments[1])    # noqa: E501
 
         n_symm01_features = self.triang_idxs_2d.shape[0] * self.n_radial
 

--- a/apax/layers/empirical.py
+++ b/apax/layers/empirical.py
@@ -1,4 +1,3 @@
-from dataclasses import field
 from typing import Any
 
 import flax.linen as nn
@@ -6,11 +5,9 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 from jax import vmap
-from jax_md import partition, space
+from jax_md import space
 
-from apax.layers.descriptor.gaussian_moment_descriptor import disp_fn, get_disp_fn
 from apax.layers.masking import mask_by_neighbor
-from apax.model.utils import NeighborSpoof
 from apax.utils.math import fp64_sum
 
 
@@ -23,23 +20,10 @@ class EmpiricalEnergyTerm(nn.Module):
 
 
 class ZBLRepulsion(EmpiricalEnergyTerm):
-    init_box: np.array = field(default_factory=lambda: np.array([0.0, 0.0, 0.0]))
     r_max: float = 6.0
     apply_mask: bool = True
-    inference_disp_fn: Any = None
 
     def setup(self):
-        if np.all(self.init_box < 1e-6):
-            # displacement function for gas phase training and predicting
-            displacement_fn = space.free()[0]
-            self.displacement = space.map_bond(displacement_fn)
-        elif self.inference_disp_fn is None:
-            # displacement function used for training on periodic systems
-            self.displacement = vmap(disp_fn, (0, 0, None, None), 0)
-        else:
-            mappable_displacement_fn = get_disp_fn(self.inference_disp_fn)
-            self.displacement = vmap(mappable_displacement_fn, (0, 0, None, None), 0)
-
         self.distance = vmap(space.distance, 0, 0)
 
         self.ke = 14.3996
@@ -73,34 +57,13 @@ class ZBLRepulsion(EmpiricalEnergyTerm):
             "rep_scale", nn.initializers.constant(rep_scale_isp), (1,)
         )
 
-    def __call__(self, R, Z, neighbor, box, offsets, perturbation=None):
-        R = R.astype(jnp.float64)
-        # R shape n_atoms x 3
+    def __call__(self, dr_vec, Z, idx):
         # Z shape n_atoms
-        # n_atoms = R.shape[0]
-        if type(neighbor) in [partition.NeighborList, NeighborSpoof]:
-            idx = neighbor.idx
-        else:
-            idx = neighbor
 
         idx_i, idx_j = idx[0], idx[1]
 
         # shape: neighbors
         Z_i, Z_j = Z[idx_i, ...], Z[idx_j, ...]
-
-        # dr_vec shape: neighbors x 3
-        if np.all(self.init_box < 1e-6):
-            # reverse conventnion to match TF
-            # distance vector for gas phase training and predicting
-            dr_vec = self.displacement(R[idx_j], R[idx_i]).astype(self.dtype)
-        else:
-            # distance vector for training on periodic systems
-            # reverse conventnion to match TF
-            Ri = R[idx_i]
-            Rj = R[idx_j]
-
-            dr_vec = self.displacement(Rj, Ri, perturbation, box).astype(self.dtype)
-            dr_vec += offsets
 
         # dr shape: neighbors
         dr = self.distance(dr_vec).astype(self.dtype)

--- a/apax/model/builder.py
+++ b/apax/model/builder.py
@@ -10,7 +10,7 @@ from apax.model.gmnn import AtomisticModel, EnergyDerivativeModel, EnergyModel
 
 
 class ModelBuilder:
-    def __init__(self, model_config: ModelConfig, n_species):
+    def __init__(self, model_config: ModelConfig, n_species: int =119):
         self.config = model_config
         self.n_species = n_species
 

--- a/apax/model/gmnn.py
+++ b/apax/model/gmnn.py
@@ -1,11 +1,14 @@
 import logging
 from dataclasses import field
-from typing import Callable, Tuple, Union
+from typing import Any, Callable, Optional, Tuple, Union
 
 import flax.linen as nn
 import jax
-from jax_md import partition
+from jax_md import partition, space
 from jax_md.util import Array
+import numpy as np
+import jax.numpy as jnp
+from jax import vmap
 
 from apax.layers.descriptor.gaussian_moment_descriptor import GaussianMomentDescriptor
 from apax.layers.empirical import EmpiricalEnergyTerm
@@ -21,6 +24,32 @@ MDModel = Tuple[partition.NeighborFn, Callable, Callable]
 
 log = logging.getLogger(__name__)
 
+def canonicalize_neighbors(neighbor):
+    if type(neighbor) in [partition.NeighborList, NeighborSpoof]:
+        idx = neighbor.idx
+    else:
+        idx = neighbor
+    return idx
+
+
+def disp_fn(ri, rj, perturbation, box):
+    dR = space.pairwise_displacement(ri, rj)
+    dR = space.transform(box, dR)
+
+    if perturbation is not None:
+        dR = dR + space.raw_transform(perturbation, dR)
+        # https://github.com/mir-group/nequip/blob/c56f48fcc9b4018a84e1ed28f762fadd5bc763f1/nequip/nn/_grad_output.py#L267
+        # https://github.com/sirmarcel/glp/blob/main/glp/calculators/utils.py
+        # other codes do R = R + strain, not dR
+        # can be implemented for efficiency
+    return dR
+
+
+def get_disp_fn(displacement):
+    def disp_fn(ri, rj, perturbation, box):
+        return displacement(ri, rj, perturbation, box=box)
+    return disp_fn
+
 
 class AtomisticModel(nn.Module):
     descriptor: nn.Module = GaussianMomentDescriptor()
@@ -30,31 +59,40 @@ class AtomisticModel(nn.Module):
 
     def __call__(
         self,
-        R: Array,
+        dr_vec: Array,
         Z: Array,
-        neighbor: Union[partition.NeighborList, NeighborSpoof, Array],
-        box,
-        offsets,
-        perturbation=None,
+        idx: Array,
+        box: Array,
+        offsets: Array,
+        perturbation: Optional[Array]=None,
     ) -> Array:
-        if type(neighbor) in [partition.NeighborList, NeighborSpoof]:
-            idx = neighbor.idx
-        else:
-            idx = neighbor
-
-        gm = self.descriptor(R, Z, idx, box, offsets, perturbation)
+        gm = self.descriptor(dr_vec, Z, idx, box, offsets, perturbation)
         h = jax.vmap(self.readout)(gm)
         output = self.scale_shift(h, Z)
 
         if self.mask_atoms:
             output = mask_by_atom(output, Z)
-
         return output
 
 
 class EnergyModel(nn.Module):
     atomistic_model: AtomisticModel = AtomisticModel()
     corrections: list[EmpiricalEnergyTerm] = field(default_factory=lambda: [])
+    init_box: np.array = field(default_factory=lambda: np.array([0.0, 0.0, 0.0]))
+    inference_disp_fn: Any = None
+
+    def setup(self):
+
+        if np.all(self.init_box < 1e-6):
+            # gas phase training and predicting
+            displacement_fn = space.free()[0]
+            self.displacement = space.map_bond(displacement_fn)
+        elif self.inference_disp_fn is None:
+            # for training on periodic systems
+            self.displacement = vmap(disp_fn, (0, 0, None, None), 0)
+        else:
+            mappable_displacement_fn = get_disp_fn(self.inference_disp_fn)
+            self.displacement = vmap(mappable_displacement_fn, (0, 0, None, None), 0)
 
     def __call__(
         self,
@@ -65,26 +103,44 @@ class EnergyModel(nn.Module):
         offsets,
         perturbation=None,
     ):
-        atomic_energies = self.atomistic_model(R, Z, neighbor, box, offsets, perturbation)
+        
+        # Distances
+        idx = canonicalize_neighbors(neighbor)
+        idx_i, idx_j = idx[0], idx[1]
+
+        # R shape n_atoms x 3
+        R = R.astype(jnp.float64)
+        Ri = R[idx_i]
+        Rj = R[idx_j]
+
+        # dr_vec shape: neighbors x 3
+        if np.all(self.init_box < 1e-6):
+            # reverse conventnion to match TF
+            # distance vector for gas phase training and predicting
+            dr_vec = self.displacement(Rj, Ri).astype(self.dtype)
+        else:
+            # distance vector for training on periodic systems
+            dr_vec = self.displacement(Rj, Ri, perturbation, box).astype(self.dtype)
+            dr_vec += offsets.astype(self.dtype)
+
+        # Model Core
+        atomic_energies = self.atomistic_model(dr_vec, Z, neighbor)
         total_energy = fp64_sum(atomic_energies)
 
         # Corrections
         for correction in self.corrections:
-            energy_correction = correction(R, Z, neighbor, box, offsets, perturbation)
+            energy_correction = correction(dr_vec, Z, neighbor)
             total_energy = total_energy + energy_correction
+
+        # TODO think of nice abstraction for predicting additional properties
         return total_energy
 
 
 class EnergyDerivativeModel(nn.Module):
-    atomistic_model: AtomisticModel = AtomisticModel()
+    # Alternatively, should this be a function transformation?
+    energy_model: EnergyModel = EnergyModel()
     corrections: list[EmpiricalEnergyTerm] = field(default_factory=lambda: [])
     calc_stress: bool = False
-
-    def setup(self):
-        self.energy_fn = EnergyModel(
-            atomistic_model=self.atomistic_model,
-            corrections=self.corrections,
-        )
 
     def __call__(
         self,
@@ -94,7 +150,7 @@ class EnergyDerivativeModel(nn.Module):
         box,
         offsets,
     ):
-        energy, neg_forces = jax.value_and_grad(self.energy_fn)(
+        energy, neg_forces = jax.value_and_grad(self.energy_model)(
             R, Z, neighbor, box, offsets
         )
         forces = -neg_forces
@@ -102,7 +158,7 @@ class EnergyDerivativeModel(nn.Module):
 
         if self.calc_stress:
             stress = stress_times_vol(
-                self.energy_fn, R, box, Z=Z, neighbor=neighbor, offsets=offsets
+                self.energy_model, R, box, Z=Z, neighbor=neighbor, offsets=offsets
             )
             prediction["stress"] = stress
 

--- a/apax/model/gmnn.py
+++ b/apax/model/gmnn.py
@@ -26,11 +26,11 @@ log = logging.getLogger(__name__)
 
 
 def canonicalize_neighbors(neighbor):
-    if type(neighbor) in [partition.NeighborList, NeighborSpoof]:
-        idx = neighbor.idx
-    else:
-        idx = neighbor
-    return idx
+    return (
+        neighbor.idx
+        if isinstance(neighbor, (partition.NeighborList, NeighborSpoof))
+        else neighbor
+    )
 
 
 def disp_fn(ri, rj, perturbation, box):

--- a/apax/train/callbacks.py
+++ b/apax/train/callbacks.py
@@ -1,0 +1,58 @@
+import logging
+
+import tensorflow as tf
+from keras.callbacks import CSVLogger, TensorBoard
+
+log = logging.getLogger(__name__)
+
+
+def initialize_callbacks(callback_configs, model_version_path):
+    log.info("Initializing Callbacks")
+
+    dummy_model = tf.keras.Model()
+    callback_dict = {
+        "csv": {
+            "class": CSVLogger,
+            "log_path": model_version_path / "log.csv",
+            "path_arg_name": "filename",
+            "kwargs": {"append": True},
+            "model": dummy_model,
+        },
+        "tensorboard": {
+            "class": TensorBoard,
+            "log_path": model_version_path,
+            "path_arg_name": "log_dir",
+            "kwargs": {},
+            "model": dummy_model,
+        },
+    }
+
+    callback_configs = [config.name for config in callback_configs]
+    if "csv" in callback_configs and "tensorboard" in callback_configs:
+        csv_idx, tb_idx = callback_configs.index("csv"), callback_configs.index(
+            "tensorboard"
+        )
+        msg = (
+            "Using both csv and tensorboard callbacks is not supported at the moment."
+            " Only the first of the two will be used."
+        )
+        print("Warning: " + msg)
+        log.warning(msg)
+        if csv_idx < tb_idx:
+            callback_configs.pop(tb_idx)
+        else:
+            callback_configs.pop(csv_idx)
+
+    callbacks = []
+    for callback_config in callback_configs:
+        callback_info = callback_dict[callback_config]
+
+        path_arg_name = callback_info["path_arg_name"]
+        path = {path_arg_name: callback_info["log_path"]}
+
+        kwargs = callback_info["kwargs"]
+        callback = callback_info["class"](**path, **kwargs)
+        callback.set_model(callback_info["model"])
+        callbacks.append(callback)
+
+    return tf.keras.callbacks.CallbackList([callback])

--- a/apax/train/eval.py
+++ b/apax/train/eval.py
@@ -8,15 +8,12 @@ import numpy as np
 from tqdm import trange
 
 from apax.config import parse_config
+from apax.data.initialization import RawDataset, initialize_dataset
 from apax.model import ModelBuilder
+from apax.train.callbacks import initialize_callbacks
 from apax.train.checkpoints import load_params
 from apax.train.metrics import initialize_metrics
-from apax.data.initialization import RawDataset, initialize_dataset
-from apax.train.callbacks import initialize_callbacks
-from apax.train.run import (
-    initialize_loss_fn,
-    setup_logging,
-)
+from apax.train.run import initialize_loss_fn, setup_logging
 from apax.train.trainer import make_step_fns
 from apax.utils.data import load_data, split_atoms, split_label
 from apax.utils.random import seed_py_np_tf

--- a/apax/train/eval.py
+++ b/apax/train/eval.py
@@ -11,10 +11,9 @@ from apax.config import parse_config
 from apax.model import ModelBuilder
 from apax.train.checkpoints import load_params
 from apax.train.metrics import initialize_metrics
+from apax.data.initialization import RawDataset, initialize_dataset
+from apax.train.callbacks import initialize_callbacks
 from apax.train.run import (
-    RawDataset,
-    initialize_callbacks,
-    initialize_dataset,
     initialize_loss_fn,
     setup_logging,
 )

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -1,182 +1,27 @@
-import dataclasses
 import logging
 import os
 from pathlib import Path
-from typing import Optional
+from typing import List
 
 import jax
 import jax.numpy as jnp
 import numpy as np
-import tensorflow as tf
-from ase import Atoms
 from flax.core.frozen_dict import freeze
-from keras.callbacks import CSVLogger, TensorBoard
 
-from apax.config import parse_config
-from apax.data.input_pipeline import TFPipeline, create_dict_dataset
-from apax.data.statistics import compute_scale_shift_parameters
+from apax.config import parse_config, LossConfig
+from apax.data.initialization import initialize_dataset, load_data_files
+
 from apax.model import ModelBuilder
 from apax.optimizer import get_opt
+from apax.train.callbacks import initialize_callbacks
 from apax.train.checkpoints import load_params
 from apax.train.loss import Loss, LossCollection
 from apax.train.metrics import initialize_metrics
 from apax.train.trainer import fit
 from apax.transfer_learning import param_transfer
-from apax.utils.data import load_data, split_atoms, split_idxs, split_label
 from apax.utils.random import seed_py_np_tf
 
 log = logging.getLogger(__name__)
-
-
-def initialize_directories(model_version_path: Path) -> None:
-    log.info("Initializing directories")
-    os.makedirs(model_version_path, exist_ok=True)
-
-
-@dataclasses.dataclass
-class RawDataset:
-    atoms_list: list[Atoms]
-    additional_labels: Optional[dict] = None
-
-
-def load_data_files(data_config, model_version_path):
-    log.info("Running Input Pipeline")
-    if data_config.data_path is not None:
-        log.info(f"Read data file {data_config.data_path}")
-        atoms_list, label_dict = load_data(data_config.data_path)
-
-        train_idxs, val_idxs = split_idxs(
-            atoms_list, data_config.n_train, data_config.n_valid
-        )
-        train_atoms_list, val_atoms_list = split_atoms(atoms_list, train_idxs, val_idxs)
-        train_label_dict, val_label_dict = split_label(label_dict, train_idxs, val_idxs)
-
-        np.savez(
-            os.path.join(model_version_path, "train_val_idxs"),
-            train_idxs=train_idxs,
-            val_idxs=val_idxs,
-        )
-
-    elif data_config.train_data_path and data_config.val_data_path is not None:
-        log.info(f"Read training data file {data_config.train_data_path}")
-        log.info(f"Read validation data file {data_config.val_data_path}")
-        train_atoms_list, train_label_dict = load_data(data_config.train_data_path)
-        val_atoms_list, val_label_dict = load_data(data_config.val_data_path)
-    else:
-        raise ValueError("input data path/paths not defined")
-
-    train_raw_ds = RawDataset(
-        atoms_list=train_atoms_list, additional_labels=train_label_dict
-    )
-    val_raw_ds = RawDataset(atoms_list=val_atoms_list, additional_labels=val_label_dict)
-
-    return train_raw_ds, val_raw_ds
-
-
-def initialize_dataset(config, raw_ds, calc_stats: bool = True):
-    inputs, labels = create_dict_dataset(
-        raw_ds.atoms_list,
-        r_max=config.model.r_max,
-        external_labels=raw_ds.additional_labels,
-        disable_pbar=config.progress_bar.disable_nl_pbar,
-        pos_unit=config.data.pos_unit,
-        energy_unit=config.data.energy_unit,
-    )
-
-    if calc_stats:
-        ds_stats = compute_scale_shift_parameters(
-            inputs,
-            labels,
-            config.data.shift_method,
-            config.data.scale_method,
-            config.data.shift_options,
-            config.data.scale_options,
-        )
-
-    dataset = TFPipeline(
-        inputs,
-        labels,
-        config.n_epochs,
-        config.data.batch_size,
-        buffer_size=config.data.shuffle_buffer_size,
-    )
-
-    if calc_stats:
-        return dataset, ds_stats
-    else:
-        return dataset
-
-
-def maximize_l2_cache():
-    import ctypes
-
-    _libcudart = ctypes.CDLL("libcudart.so")
-    # Set device limit on the current device
-    # cudaLimitMaxL2FetchGranularity = 0x05
-    pValue = ctypes.cast((ctypes.c_int * 1)(), ctypes.POINTER(ctypes.c_int))
-    _libcudart.cudaDeviceSetLimit(ctypes.c_int(0x05), ctypes.c_int(128))
-    _libcudart.cudaDeviceGetLimit(pValue, ctypes.c_int(0x05))
-    assert pValue.contents.value == 128
-
-
-def initialize_callbacks(callback_configs, model_version_path):
-    log.info("Initializing Callbacks")
-
-    dummy_model = tf.keras.Model()
-    callback_dict = {
-        "csv": {
-            "class": CSVLogger,
-            "log_path": model_version_path / "log.csv",
-            "path_arg_name": "filename",
-            "kwargs": {"append": True},
-            "model": dummy_model,
-        },
-        "tensorboard": {
-            "class": TensorBoard,
-            "log_path": model_version_path,
-            "path_arg_name": "log_dir",
-            "kwargs": {},
-            "model": dummy_model,
-        },
-    }
-
-    callback_configs = [config.name for config in callback_configs]
-    if "csv" in callback_configs and "tensorboard" in callback_configs:
-        csv_idx, tb_idx = callback_configs.index("csv"), callback_configs.index(
-            "tensorboard"
-        )
-        msg = (
-            "Using both csv and tensorboard callbacks is not supported at the moment."
-            " Only the first of the two will be used."
-        )
-        print("Warning: " + msg)
-        log.warning(msg)
-        if csv_idx < tb_idx:
-            callback_configs.pop(tb_idx)
-        else:
-            callback_configs.pop(csv_idx)
-
-    callbacks = []
-    for callback_config in callback_configs:
-        callback_info = callback_dict[callback_config]
-
-        path_arg_name = callback_info["path_arg_name"]
-        path = {path_arg_name: callback_info["log_path"]}
-
-        kwargs = callback_info["kwargs"]
-        callback = callback_info["class"](**path, **kwargs)
-        callback.set_model(callback_info["model"])
-        callbacks.append(callback)
-
-    return tf.keras.callbacks.CallbackList([callback])
-
-
-def initialize_loss_fn(loss_config_list):
-    log.info("Initializing Loss Function")
-    loss_funcs = []
-    for loss in loss_config_list:
-        loss_funcs.append(Loss(**loss.model_dump()))
-    return LossCollection(loss_funcs)
 
 
 def setup_logging(log_file, log_level):
@@ -194,6 +39,20 @@ def setup_logging(log_file, log_level):
     logging.basicConfig(filename=log_file, level=log_levels[log_level])
 
 
+
+def initialize_directories(model_version_path: Path) -> None:
+    log.info("Initializing directories")
+    os.makedirs(model_version_path, exist_ok=True)
+
+
+def initialize_loss_fn(loss_config_list: List[LossConfig]) -> LossCollection:
+    log.info("Initializing Loss Function")
+    loss_funcs = []
+    for loss in loss_config_list:
+        loss_funcs.append(Loss(**loss.model_dump()))
+    return LossCollection(loss_funcs)
+
+
 def run(user_config, log_file="train.log", log_level="error"):
     setup_logging(log_file, log_level)
     log.info("Loading user config")
@@ -201,8 +60,6 @@ def run(user_config, log_file="train.log", log_level="error"):
 
     seed_py_np_tf(config.seed)
     rng_key = jax.random.PRNGKey(config.seed)
-    if config.maximize_l2_cache:
-        maximize_l2_cache()
 
     experiment = Path(config.data.experiment)
     directory = Path(config.data.directory)
@@ -219,6 +76,9 @@ def run(user_config, log_file="train.log", log_level="error"):
     train_ds, ds_stats = initialize_dataset(config, train_raw_ds)
     val_ds = initialize_dataset(config, val_raw_ds, calc_stats=False)
 
+    train_ds.set_batch_size(config.data.batch_size)
+    val_ds.set_batch_size(config.data.val_batch_size)
+
     log.info("Initializing Model")
     init_input = train_ds.init_input()
     R, Z, idx, init_box, offsets = (
@@ -229,9 +89,7 @@ def run(user_config, log_file="train.log", log_level="error"):
         jnp.array(init_input["offsets"][0]),
     )
 
-    # TODO n_species should be optional since it's already
-    # TODO determined by the shape of shift and scale
-    builder = ModelBuilder(config.model.get_dict(), n_species=ds_stats.n_species)
+    builder = ModelBuilder(config.model.get_dict())
     model = builder.build_energy_derivative_model(
         scale=ds_stats.elemental_scale,
         shift=ds_stats.elemental_shift,

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -38,11 +38,6 @@ def setup_logging(log_file, log_level):
     logging.basicConfig(filename=log_file, level=log_levels[log_level])
 
 
-def initialize_directories(model_version_path: Path) -> None:
-    log.info("Initializing directories")
-    os.makedirs(model_version_path, exist_ok=True)
-
-
 def initialize_loss_fn(loss_config_list: List[LossConfig]) -> LossCollection:
     log.info("Initializing Loss Function")
     loss_funcs = []
@@ -62,8 +57,8 @@ def run(user_config, log_file="train.log", log_level="error"):
     experiment = Path(config.data.experiment)
     directory = Path(config.data.directory)
     model_version_path = directory / experiment
-
-    initialize_directories(model_version_path)
+    log.info("Initializing directories")
+    model_version_path.mkdir(exist_ok=True)
     config.dump_config(model_version_path)
 
     callbacks = initialize_callbacks(config.callbacks, model_version_path)

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -8,9 +8,8 @@ import jax.numpy as jnp
 import numpy as np
 from flax.core.frozen_dict import freeze
 
-from apax.config import parse_config, LossConfig
+from apax.config import LossConfig, parse_config
 from apax.data.initialization import initialize_dataset, load_data_files
-
 from apax.model import ModelBuilder
 from apax.optimizer import get_opt
 from apax.train.callbacks import initialize_callbacks

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -39,7 +39,6 @@ def setup_logging(log_file, log_level):
     logging.basicConfig(filename=log_file, level=log_levels[log_level])
 
 
-
 def initialize_directories(model_version_path: Path) -> None:
     log.info("Initializing directories")
     os.makedirs(model_version_path, exist_ok=True)
@@ -110,6 +109,7 @@ def run(user_config, log_file="train.log", log_level="error"):
 
     batched_model = jax.vmap(model.apply, in_axes=(None, 0, 0, 0, 0, 0))
 
+    # TODO rework optimizer initialization and lr keywords
     steps_per_epoch = train_ds.steps_per_epoch()
     n_epochs = config.n_epochs
     transition_steps = steps_per_epoch * n_epochs - config.optimizer.transition_begin

--- a/tests/regression_tests/apax_config.yaml
+++ b/tests/regression_tests/apax_config.yaml
@@ -85,5 +85,3 @@ checkpoints:
 progress_bar:
   disable_epoch_pbar: true
   disable_nl_pbar: true
-
-maximize_l2_cache: false

--- a/tests/unit_tests/data/test_input_pipeline.py
+++ b/tests/unit_tests/data/test_input_pipeline.py
@@ -6,7 +6,7 @@ from ase.calculators.singlepoint import SinglePointCalculator
 from jax import vmap
 
 from apax.data.input_pipeline import PadToSpecificSize, AtomisticDataset, create_dict_dataset
-from apax.layers.descriptor.gaussian_moment_descriptor import disp_fn
+from apax.model.gmnn import disp_fn
 from apax.utils.convert import atoms_to_arrays
 from apax.utils.data import split_atoms, split_idxs
 from apax.utils.random import seed_py_np_tf

--- a/tests/unit_tests/data/test_input_pipeline.py
+++ b/tests/unit_tests/data/test_input_pipeline.py
@@ -5,7 +5,7 @@ from ase import Atoms
 from ase.calculators.singlepoint import SinglePointCalculator
 from jax import vmap
 
-from apax.data.input_pipeline import PadToSpecificSize, TFPipeline, create_dict_dataset
+from apax.data.input_pipeline import PadToSpecificSize, AtomisticDataset, create_dict_dataset
 from apax.layers.descriptor.gaussian_moment_descriptor import disp_fn
 from apax.utils.convert import atoms_to_arrays
 from apax.utils.data import split_atoms, split_idxs
@@ -41,7 +41,7 @@ def test_input_pipeline(example_atoms, calc_results, num_data, external_labels):
         disable_pbar=True,
     )
 
-    ds = TFPipeline(
+    ds = AtomisticDataset(
         inputs,
         labels,
         1,

--- a/tests/unit_tests/data/test_input_pipeline.py
+++ b/tests/unit_tests/data/test_input_pipeline.py
@@ -45,9 +45,9 @@ def test_input_pipeline(example_atoms, calc_results, num_data, external_labels):
         inputs,
         labels,
         1,
-        batch_size,
         buffer_size=1000,
     )
+    ds.set_batch_size(batch_size)
     assert ds.steps_per_epoch() == num_data // batch_size
 
     ds = ds.shuffle_and_batch()

--- a/tests/unit_tests/layers/descriptor/test_gaussian_moment_descriptor.py
+++ b/tests/unit_tests/layers/descriptor/test_gaussian_moment_descriptor.py
@@ -6,18 +6,26 @@ from apax.layers.descriptor.gaussian_moment_descriptor import GaussianMomentDesc
 
 
 def test_gaussian_moment_descriptor():
-    R = jnp.array([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=jnp.float32)
+    dR = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+            [-1.0, 1.0, 0.0],
+            [0.0, -1.0, 0.0],
+            [1.0, -1.0, 0.0],
+        ],
+        dtype=jnp.float32
+    )
     Z = jnp.array([8, 1, 1])
     neighbor = jnp.array([[1, 2, 0, 2, 0, 1], [0, 0, 1, 1, 2, 2]])
-    box = np.array([0.0, 0.0, 0.0])
-    offsets = jnp.full([6, 3], 0)
 
     descriptor = GaussianMomentDescriptor()
 
     key = jax.random.PRNGKey(0)
-    params = descriptor.init(key, R, Z, neighbor, box, offsets)
-    result = descriptor.apply(params, R, Z, neighbor, box, offsets)
-    result_jit = jax.jit(descriptor.apply)(params, R, Z, neighbor, box, offsets)
+    params = descriptor.init(key, dR, Z, neighbor)
+    result = descriptor.apply(params, dR, Z, neighbor)
+    result_jit = jax.jit(descriptor.apply)(params, dR, Z, neighbor)
 
     assert result.shape == (3, 360)
     assert result_jit.shape == (3, 360)


### PR DESCRIPTION
This PR fixes a bug in the data pipeline where the validation batch size was not used and instead the train batch size was used for everything.
Further:
- I tested the max l2cache option and found it to not do anything, hence I removed it.
- TFPipeline was renamed to AtomisticDataset
- AtomisticDataset is no longer initialized with the batch size
- creating a tf.data dataset from dicts was moved to a separate function
- some type hints
- callback initialization was moved to separate submodule
- the calculation of pairwise distances from cartesian positions was moved from the descriptor and empirical corrections to the energy model. This greatly simplifies the call signature of these models/layers and reduces code duplication.