### PR TITLE
CLI test

### DIFF
--- a/apax/cli/apax_app.py
+++ b/apax/cli/apax_app.py
@@ -1,6 +1,6 @@
-import sys
 import importlib.metadata
 import importlib.resources as pkg_resources
+import sys
 from pathlib import Path
 
 import typer
@@ -252,7 +252,3 @@ def main(
 ):
     # Taken from https://github.com/zincware/dask4dvc/blob/main/dask4dvc/cli/main.py
     _ = version
-
-
-# if __name__ == "__main__":
-#     app()

--- a/apax/cli/apax_app.py
+++ b/apax/cli/apax_app.py
@@ -1,3 +1,4 @@
+import sys
 import importlib.metadata
 import importlib.resources as pkg_resources
 from pathlib import Path
@@ -211,6 +212,7 @@ def template_train_config(
 
     if Path(config_path).is_file():
         console.print("There is already a config file in the working directory.")
+        sys.exit(1)
     else:
         with open(config_path, "w") as config:
             config.write(template_content)
@@ -229,6 +231,7 @@ def template_md_config():
 
     if Path(config_path).is_file():
         console.print("There is already a config file in the working directory.")
+        sys.exit(1)
     else:
         with open(config_path, "w") as config:
             config.write(template_content)
@@ -251,5 +254,5 @@ def main(
     _ = version
 
 
-if __name__ == "__main__":
-    app()
+# if __name__ == "__main__":
+#     app()

--- a/apax/cli/templates/md_config_minimal.yaml
+++ b/apax/cli/templates/md_config_minimal.yaml
@@ -1,8 +1,11 @@
-temperature: <T> # K
-duration: <DURATION> #fs
-n_inner: 100 # compiled innner steps
-sampling_rate: 10 # dump interval
-dt: 0.5 # fs time step
+ensemble:
+  name: nvt
+  dt: 0.5 # fs time step
+  temperature: <T> # K
+
+duration: <DURATION> # fs
+n_inner: 1 # compiled innner steps
+sampling_rate: 1  # dump interval
 dr_threshold: 0.5 # Neighborlist skin
 
 sim_dir: md

--- a/tests/integration_tests/cli/test_app.py
+++ b/tests/integration_tests/cli/test_app.py
@@ -1,0 +1,65 @@
+import pathlib
+import pytest
+from typer.testing import CliRunner
+import yaml
+
+from apax.cli.apax_app import app, validate_app, template_app
+
+
+TEST_PATH = pathlib.Path(__file__).parent.resolve()
+
+runner = CliRunner()
+
+
+def test_cli_basic(get_tmp_path):
+    pytest.MonkeyPatch().chdir(get_tmp_path)
+    result = runner.invoke(app, ["-h"])
+    assert result.exit_code == 0
+    assert "Commands" in result.stdout
+
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+
+    result = runner.invoke(template_app, "train")
+    assert result.exit_code == 0
+    result = runner.invoke(template_app, "train")
+    assert result.exit_code == 1
+
+    result = runner.invoke(template_app, ["train", "--full"])
+    assert result.exit_code == 0
+    result = runner.invoke(template_app, ["train", "--full"])
+    assert result.exit_code == 1
+
+    result = runner.invoke(template_app, "md")
+    assert result.exit_code == 0
+    result = runner.invoke(template_app, "md")
+    assert result.exit_code == 1
+
+    # Expect the unedited templates to fail
+    result = runner.invoke(validate_app, ["train", "config.yaml"])
+    assert result.exit_code == 1
+
+    result = runner.invoke(validate_app, ["train", "config_full.yaml"])
+    assert result.exit_code == 1
+
+    result = runner.invoke(validate_app, ["md", "md_config.yaml"])
+    assert result.exit_code == 1
+
+    # Load and fix the train config, then try again
+    # TODO to the same for md
+    with open("config_full.yaml", "r") as stream:
+        model_config_dict = yaml.safe_load(stream)
+
+    model_config_dict["n_epochs"] = 100
+    model_config_dict["data"]["data_path"] = "dataset.extxyz"
+
+    with open("config_full_fixed.yaml", "w") as conf:
+        yaml.dump(model_config_dict, conf, default_flow_style=False)
+
+    result = runner.invoke(validate_app, ["train", "config_full_fixed.yaml"])
+    assert result.exit_code == 0
+    assert "Success!" in result.stdout
+
+    result = runner.invoke(app, ["visualize", "config_full_fixed.yaml"])
+    assert result.exit_code == 0
+    assert "Total Parameters" in result.stdout


### PR DESCRIPTION
I have added an integration test for the CLI which runs all of the cheap commands like templating and validation.
This has the added benefit that we can detect whether our config templates are still valid.
We can add tests for the training and md commands once #200 is merged, since it provides some nice fixtures for dataset creation.