### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `apax`: Atomstic learned Potentials in JAX!
+# `apax`: Atomistic learned Potentials in JAX!
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
Maybe we should fix the name typo directly in main?