### PR TITLE
fix `restore_single_parameters`

### DIFF
--- a/apax/train/checkpoints.py
+++ b/apax/train/checkpoints.py
@@ -147,7 +147,7 @@ def restore_single_parameters(model_dir: Path) -> Tuple[Config, FrozenDict]:
     """
     model_dir = Path(model_dir)
     model_config = parse_config(model_dir / "config.yaml")
-    model_config.data.directory = model_dir.parent.resolve().as_posix()
+    model_config.data.directory = model_dir.resolve().as_posix()
 
     ckpt_dir = model_config.data.model_version_path
     return model_config, load_params(ckpt_dir)


### PR DESCRIPTION
Maybe this is an issue with ZnTrack, but the structure is:

```
model_dir/
 - best/
 - latest/
 - config.yaml
 - train.log
```

so I think the `.parent` going to the parent directory of `model_dir` is one too far?