### PR TITLE
added model loading edge case for `experiment=""`

### DIFF
--- a/apax/train/checkpoints.py
+++ b/apax/train/checkpoints.py
@@ -147,7 +147,11 @@ def restore_single_parameters(model_dir: Path) -> Tuple[Config, FrozenDict]:
     """
     model_dir = Path(model_dir)
     model_config = parse_config(model_dir / "config.yaml")
-    model_config.data.directory = model_dir.parent.resolve().as_posix()
+
+    if model_config.data.experiment == "":
+        model_config.data.directory = model_dir.resolve().as_posix()
+    else:
+        model_config.data.directory = model_dir.parent.resolve().as_posix()
 
     ckpt_dir = model_config.data.model_version_path
     return model_config, load_params(ckpt_dir)

--- a/tests/integration_tests/md/test_model_loading.py
+++ b/tests/integration_tests/md/test_model_loading.py
@@ -22,10 +22,13 @@ def test_model_loading(get_tmp_path, get_sample_input):
     ckpt = {"model": {"params": params}, "epoch": 0}
     ckpt_dir1 = pathlib.Path("models/apax_dummy/best")
     ckpt_dir2 = pathlib.Path("../models/apax_dummy/best").resolve()
+    ckpt_dir3 = pathlib.Path("models/best")
 
-    ckpt_dirs = [ckpt_dir1, ckpt_dir2]
-    for ckpt_dir in ckpt_dirs:
+    ckpt_dirs = [ckpt_dir1, ckpt_dir2, ckpt_dir3]
+    experiments = ["apax_dummy", "apax_dummy", ""]
+    for ckpt_dir, exp in zip(ckpt_dirs, experiments):
         ckpt_dir.mkdir(exist_ok=True, parents=True)
+        model_config.data.experiment = exp
         model_config.dump_config(ckpt_dir.parent)
 
         checkpoints.save_checkpoint(


### PR DESCRIPTION
model loading could cause problems when experiment was set to an empty string since the last release. For IPS compatibility, I've fixed this edge case on the Apax side.