### PR TITLE
JIT multiple train steps

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -13,7 +13,7 @@ jobs:
         uses: psf/black@stable
         with:
           src: "./apax"
-          version: "22.10.0"
+          version: "22.12.0"
 
   isort:
     runs-on: ubuntu-latest
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install isort
         run: |
-          pip install isort==5.10.1
+          pip install isort==5.12.0
 
       - name: run isort
         run: |

--- a/apax/config/train_config.py
+++ b/apax/config/train_config.py
@@ -279,7 +279,11 @@ class Config(BaseModel, frozen=True, extra="forbid"):
     ----------
 
     n_epochs: Number of training epochs.
+    patience: Number of epochs without improvement before trainings gets terminated.
     seed: Random seed.
+    n_models: Number of models to be trained at once.
+    n_jitted_steps: Number of train batches to be processed in a compiled loop.
+        Can yield singificant speedups for small structures or small batch sizes.
     data: :class: `Data` <config.DataConfig> configuration.
     model: :class: `Model` <config.ModelConfig> configuration.
     metrics: List of :class: `metric` <config.MetricsConfig> configurations.
@@ -294,6 +298,7 @@ class Config(BaseModel, frozen=True, extra="forbid"):
     patience: Optional[PositiveInt] = None
     seed: int = 1
     n_models: int = 1
+    n_jitted_steps: int = 1
 
     data: DataConfig
     model: ModelConfig = ModelConfig()

--- a/apax/data/input_pipeline.py
+++ b/apax/data/input_pipeline.py
@@ -174,6 +174,7 @@ class AtomisticDataset:
         """
         self.n_epoch = n_epoch
         self.batch_size = None
+        self.n_jit_steps = 1
         self.buffer_size = buffer_size
 
         max_atoms, max_nbrs = find_largest_system(inputs)
@@ -186,6 +187,9 @@ class AtomisticDataset:
 
     def set_batch_size(self, batch_size: int):
         self.batch_size = self.validate_batch_size(batch_size)
+    
+    def batch_multiple_steps(self, n_steps: int):
+        self.n_jit_steps = n_steps
 
     def _check_batch_size(self):
         if self.batch_size is None:
@@ -208,7 +212,7 @@ class AtomisticDataset:
         number of steps, and all batches have the same length. To do so, some training
         data are dropped in each epoch.
         """
-        return self.n_data // self.batch_size
+        return self.n_data // self.batch_size // self.n_jit_steps
 
     def init_input(self) -> Dict[str, np.ndarray]:
         """Returns first batch of inputs and labels to init the model."""
@@ -240,15 +244,19 @@ class AtomisticDataset:
             Iterator that returns inputs and labels of one batch in each step.
         """
         self._check_batch_size()
-        shuffled_ds = (
+        ds = (
             self.ds.shuffle(buffer_size=self.buffer_size)
             .repeat(self.n_epoch)
             .batch(batch_size=self.batch_size)
             .map(PadToSpecificSize(self.max_atoms, self.max_nbrs))
         )
 
-        shuffled_ds = prefetch_to_single_device(shuffled_ds.as_numpy_iterator(), 2)
-        return shuffled_ds
+        if self.n_jit_steps > 1:
+            print("JIT BATCH")
+            ds = ds.batch(batch_size=self.n_jit_steps)
+
+        ds = prefetch_to_single_device(ds.as_numpy_iterator(), 2)
+        return ds
 
     def batch(self) -> Iterator[jax.Array]:
         self._check_batch_size()

--- a/apax/data/input_pipeline.py
+++ b/apax/data/input_pipeline.py
@@ -252,7 +252,6 @@ class AtomisticDataset:
         )
 
         if self.n_jit_steps > 1:
-            print("JIT BATCH")
             ds = ds.batch(batch_size=self.n_jit_steps)
 
         ds = prefetch_to_single_device(ds.as_numpy_iterator(), 2)

--- a/apax/data/input_pipeline.py
+++ b/apax/data/input_pipeline.py
@@ -187,7 +187,7 @@ class AtomisticDataset:
 
     def set_batch_size(self, batch_size: int):
         self.batch_size = self.validate_batch_size(batch_size)
-    
+
     def batch_multiple_steps(self, n_steps: int):
         self.n_jit_steps = n_steps
 

--- a/apax/train/metrics.py
+++ b/apax/train/metrics.py
@@ -9,7 +9,13 @@ from apax.utils.math import normed_dotp
 log = logging.getLogger(__name__)
 
 
-class RootAverage(metrics.Average):
+class Averagefp64(metrics.Average):
+    @classmethod
+    def empty(cls) -> metrics.Metric:
+        return cls(total=jnp.array(0, jnp.float64), count=jnp.array(0, jnp.int64))
+
+
+class RootAverage(Averagefp64):
     """
     Modifies the `compute` method of `metrics.Average` to obtain the root of the average.
     Meant to be used with `mse_fn`.
@@ -59,7 +65,7 @@ def make_single_metric(key: str, reduction: str) -> metrics.Average:
     if reduction == "rmse":
         metric = RootAverage
     else:
-        metric = metrics.Average
+        metric = Averagefp64
 
     reduction_fn = reduction_fns[reduction]
     reduction_fn = partial(reduction_fn, key=key)

--- a/apax/train/run.py
+++ b/apax/train/run.py
@@ -117,4 +117,5 @@ def run(user_config, log_level="error"):
         patience=config.patience,
         disable_pbar=config.progress_bar.disable_epoch_pbar,
         is_ensemble=config.n_models > 1,
+        n_jitted_steps=config.n_jitted_steps,
     )

--- a/apax/train/trainer.py
+++ b/apax/train/trainer.py
@@ -30,6 +30,7 @@ def fit(
     patience: Optional[int] = None,
     disable_pbar: bool = False,
     is_ensemble=False,
+    n_jitted_steps=1,
 ):
     log.info("Beginning Training")
     callbacks.on_train_begin()
@@ -37,8 +38,6 @@ def fit(
     latest_dir = ckpt_dir / "latest"
     best_dir = ckpt_dir / "best"
     ckpt_manager = CheckpointManager()
-
-    n_jitted_steps = 4 # Move to arg
 
     train_step, val_step = make_step_fns(
         loss_fn, Metrics, model=state.apply_fn, sam_rho=sam_rho, is_ensemble=is_ensemble

--- a/apax/train/trainer.py
+++ b/apax/train/trainer.py
@@ -76,10 +76,13 @@ def fit(
             callbacks.on_train_batch_begin(batch=batch_idx)
 
             batch = next(batch_train_ds)
-            ((state, train_batch_metrics), batch_loss,) = train_step(
-                 (state, train_batch_metrics),
-                 batch,
-             )
+            (
+                (state, train_batch_metrics),
+                batch_loss,
+            ) = train_step(
+                (state, train_batch_metrics),
+                batch,
+            )
 
             epoch_loss["train_loss"] += jnp.mean(batch_loss)
             callbacks.on_train_batch_end(batch=batch_idx)

--- a/apax/train/trainer.py
+++ b/apax/train/trainer.py
@@ -76,13 +76,10 @@ def fit(
             callbacks.on_train_batch_begin(batch=batch_idx)
 
             batch = next(batch_train_ds)
-            (
-                (state, train_batch_metrics),
-                batch_loss,
-            ) = train_step(
-                (state, train_batch_metrics),
-                batch,
-            )
+            ((state, train_batch_metrics), batch_loss,) = train_step(
+                 (state, train_batch_metrics),
+                 batch,
+             )
 
             epoch_loss["train_loss"] += jnp.mean(batch_loss)
             callbacks.on_train_batch_end(batch=batch_idx)


### PR DESCRIPTION
Added an option to jit multiple train steps using lax.scan to iterate over an additional batch axis. 
The speedups this enables can be significant when training on small structures, when using small batch sizes or both.
It's fully compatible with training ensembles.