### PR TITLE
Input Autocomplete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ tmp/
 .traj
 .h5
 events.out.*
+*.schema.json
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If you are using VSCode, you can utilize them to lint and autocomplete your inpu
 ```json
 {
     "yaml.schemas": {
-        
+
         "/absolute/path/to/apaxtrain.schema.json": [
             "train.yaml"
         ]

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ See the [Jax installation instructions](https://github.com/google/jax#installati
 
 In order to train a model, you need to run
 
-```python
+```bash
 apax train config.yaml
 ```
 
 We offer some input file templates to get new users started as quickly as possible.
 Simply run the following commands and add the appropriate entries in the marked fields
 
-```python
+```bash
 apax template train # use --full for a template with all input options
 ```
 
@@ -79,13 +79,39 @@ The documentation can convenienty be accessed by running `apax docs`.
 There are two ways in which `apax` models can be used for molecular dynamics out of the box.
 High performance NVT simulations using JaxMD can be started with the CLI by running
 
-```python
+```bash
 apax md config.yaml md_config.yaml
 ```
 
 A template command for MD input files is provided as well.
 
 The second way is to use the ASE calculator provided in `apax.md`.
+
+
+## Input File Auto-Completion
+
+use the following command to generate JSON schemata for training and validation files:
+
+```bash
+apax schema
+```
+
+If you are using VSCode, you can utilize them to lint and autocomplete your input files by including them in `.vscode/settings.json`
+
+```json
+{
+    "yaml.schemas": {
+        
+        "/absolute/path/to/apaxtrain.schema.json": [
+            "train.yaml"
+        ]
+        ,
+        "/absolute/path/to/apaxmd.schema.json": [
+            "md.yaml"
+        ]
+    }
+}
+```
 
 
 ## Authors

--- a/apax/cli/apax_app.py
+++ b/apax/cli/apax_app.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import importlib.resources as pkg_resources
+import json
 import sys
 from pathlib import Path
 
@@ -91,6 +92,23 @@ def docs():
     """
     console.print("Opening apax's docs at https://apax.readthedocs.io/en/latest/")
     typer.launch("https://apax.readthedocs.io/en/latest/")
+
+
+@app.command()
+def schema():
+    """
+    Generating JSON schemata for autocompletion of train/md inputs in VSCode.
+    """
+    console.print("Generating JSON schema")
+    from apax.config import Config, MDConfig
+
+    train_schema = Config.model_json_schema()
+    md_schema = MDConfig.model_json_schema()
+    with open("./apaxtrain.schema.json", "w") as f:
+        f.write(json.dumps(train_schema, indent=2))
+
+    with open("./apaxmd.schema.json", "w") as f:
+        f.write(json.dumps(md_schema, indent=2))
 
 
 @validate_app.command("train")


### PR DESCRIPTION
I have implemented a new CLI command which dumps JSON schemata for the training and MD input files.
These can be included in the vscode settings in order to lint and autocomplete apax input files.