### PR TITLE
fixed memory leak in pbp ds

### DIFF
--- a/apax/config/train_config.py
+++ b/apax/config/train_config.py
@@ -76,10 +76,14 @@ class PBPDatset(DatasetConfig, extra="forbid"):
     ----------
     num_workers : int
         | Number of batches to be processed in parallel.
+    reset_every : int
+        | Number of epochs before reinitializing the ProcessPoolExcecutor.
+        | Avoids memory leaks.
     """
 
     processing: Literal["pbp"] = "pbp"
     num_workers: PositiveInt = 10
+    reset_every: PositiveInt = 10
 
 
 class DataConfig(BaseModel, extra="forbid"):

--- a/apax/data/input_pipeline.py
+++ b/apax/data/input_pipeline.py
@@ -449,6 +449,7 @@ class PerBatchPaddedDataset(InMemoryDataset):
         n_epochs,
         n_jit_steps=1,
         num_workers: Optional[int] = None,
+        reset_every: int = 10,
         pos_unit: str = "Ang",
         energy_unit: str = "eV",
         pre_shuffle=False,
@@ -490,6 +491,7 @@ class PerBatchPaddedDataset(InMemoryDataset):
         self.prepare_batch = BatchProcessor(cutoff, forces, stress)
 
         self.count = 0
+        self.reset_every = reset_every
         self.max_count = self.n_epochs * self.steps_per_epoch()
         self.buffer = deque()
 
@@ -513,7 +515,7 @@ class PerBatchPaddedDataset(InMemoryDataset):
             self.buffer = deque()
 
             # reinitialize PPE from time to time to avoid memory leak
-            if n % 10 == 0:
+            if n % self.reset_every == 0:
                 self.process_pool = ProcessPoolExecutor(self.num_workers)
 
             if self.should_shuffle:

--- a/apax/data/input_pipeline.py
+++ b/apax/data/input_pipeline.py
@@ -512,6 +512,10 @@ class PerBatchPaddedDataset(InMemoryDataset):
             self.count = 0
             self.buffer = deque()
 
+            # reinitialize PPE from time to time to avoid memory leak
+            if n % 10 == 0:
+                self.process_pool = ProcessPoolExecutor(self.num_workers)
+
             if self.should_shuffle:
                 shuffle(self.data)
 


### PR DESCRIPTION
by reinitializing the processpoolexcecutor every couple of epochs, we avoid a memory leak.
Not entirely sure what causes it in the first place but this is the simplest solution I can think of. 
While reinitializing every epoch is perfectly fine for large datasets, small datasets can get a slight performance hit when restarting the processes all the time.
Since even MP/SPICE can go for more than 10 epochs just fine, I think it's okay to hardcode it to 10.