### PR TITLE
use `store="time"`

### DIFF
--- a/apax/md/io.py
+++ b/apax/md/io.py
@@ -70,7 +70,7 @@ class H5TrajHandler(TrajHandler):
         self.sampling_rate = sampling_rate
         self.traj_path = traj_path
         self.time_step = time_step
-        self.db = znh5md.IO(self.traj_path, timestep=self.time_step)
+        self.db = znh5md.IO(self.traj_path, timestep=self.time_step, store="time")
 
         self.step_counter = 0
         self.buffer = []


### PR DESCRIPTION
with https://github.com/MDAnalysis/mdanalysis/pull/4615 MDAnalyis only supports `store=time`.
This is also testes here https://github.com/zincware/ZnH5MD/blob/e3f08c2a57355a853e66c51150b9a919060ddb2b/tests/test_mda.py#L19

Most files that we generate will not be analyzed through MDAnalysis but the trajectory files are an exception. As long as MDAnalysis does not support fixed time / step information I'd suggest using this configuration and accept that it will produce slightly larger files for the convenience of being able to analyze them more easily. 