### PR TITLE
fix `batch_eval`

### DIFF
--- a/apax/md/ase_calc.py
+++ b/apax/md/ase_calc.py
@@ -321,7 +321,7 @@ class ASECalculator(Calculator):
             # than the batch_size,  which is why we check this explicitly
             num_strucutres_in_batch = results["energy"].shape[0]
             for j in range(num_strucutres_in_batch):
-                atoms = atoms_list[i].copy()
+                atoms = atoms_list[i * batch_size + j].copy()
                 atoms.calc = SinglePointCalculator(atoms=atoms, **unpadded_results[j])
                 evaluated_atoms_list.append(atoms)
             pbar.update(batch_size)


### PR DESCRIPTION
Fix a bug in the batch_eval code that causes the wrong atoms to be copied