### PR TITLE
[MDAnalysis fix]: Do not save units

### DIFF
--- a/apax/md/io.py
+++ b/apax/md/io.py
@@ -70,7 +70,7 @@ class H5TrajHandler(TrajHandler):
         self.sampling_rate = sampling_rate
         self.traj_path = traj_path
         self.time_step = time_step
-        self.db = znh5md.IO(self.traj_path, timestep=self.time_step, store="time")
+        self.db = znh5md.IO(self.traj_path, timestep=self.time_step, store="time", save_units=False)
 
         self.step_counter = 0
         self.buffer = []

--- a/apax/md/io.py
+++ b/apax/md/io.py
@@ -70,7 +70,9 @@ class H5TrajHandler(TrajHandler):
         self.sampling_rate = sampling_rate
         self.traj_path = traj_path
         self.time_step = time_step
-        self.db = znh5md.IO(self.traj_path, timestep=self.time_step, store="time", save_units=False)
+        self.db = znh5md.IO(
+            self.traj_path, timestep=self.time_step, store="time", save_units=False
+        )
 
         self.step_counter = 0
         self.buffer = []


### PR DESCRIPTION
MDAnalysis can not deal with e.g. "Angstrom/fs" units for velocities. Thus we disable this here. ZnH5MD does not convert units and we assume ASE units everywhere.