### PR TITLE
switch ase batch predict to CachedDataset

### DIFF
--- a/apax/md/ase_calc.py
+++ b/apax/md/ase_calc.py
@@ -13,7 +13,7 @@ from matscipy.neighbours import neighbour_list
 from tqdm import trange
 
 from apax.data.input_pipeline import (
-    OTFInMemoryDataset, CachedInMemoryDataset,
+    CachedInMemoryDataset,
 )
 from apax.model import ModelBuilder
 from apax.train.checkpoints import check_for_ensemble, restore_parameters

--- a/apax/md/ase_calc.py
+++ b/apax/md/ase_calc.py
@@ -13,7 +13,7 @@ from matscipy.neighbours import neighbour_list
 from tqdm import trange
 
 from apax.data.input_pipeline import (
-    OTFInMemoryDataset,
+    OTFInMemoryDataset, CachedInMemoryDataset,
 )
 from apax.model import ModelBuilder
 from apax.train.checkpoints import check_for_ensemble, restore_parameters
@@ -283,7 +283,7 @@ class ASECalculator(Calculator):
 
         init_box = atoms_list[0].cell.array
 
-        dataset = OTFInMemoryDataset(
+        dataset = CachedInMemoryDataset(
             atoms_list,
             self.model_config.model.basis.r_max,
             batch_size,
@@ -331,6 +331,7 @@ class ASECalculator(Calculator):
                 evaluated_atoms_list.append(atoms)
             pbar.update(batch_size)
         pbar.close()
+        dataset.cleanup()
         return evaluated_atoms_list
 
     @property


### PR DESCRIPTION
When calling batch eval in a loop, the OTFInMemoryDataset would leak memory. I swtched it with the cached dataset.