### PR TITLE
cleaned up validation error messages

### DIFF
--- a/apax/cli/apax_app.py
+++ b/apax/cli/apax_app.py
@@ -146,6 +146,7 @@ def format_error(error):
     msg += "\n"
     return msg
 
+
 def cleanup_error(e):
     e_clean = []
     for error in e.errors():
@@ -153,7 +154,6 @@ def cleanup_error(e):
         e_clean.append(format_error(error))
     e_clean = "".join(e_clean)
     return e_clean
-
 
 
 @validate_app.command("train")


### PR DESCRIPTION
removes the url from the valiation errors
example
```
apax validate train train . yaml
>>> 3 validation errors for config
>>> n_epochs
>>>     Field required
>>>     input_type: dict
>>> nepochs
>>>     Extra inputs are not permitted
>>>     input_type: int
>>>     input: 1000
>>> data . directory
>>>     Field required
>>>     input_type: dict
>>> Configuration Invalid !
```