### PR TITLE
Fix Grammar in Docs

### DIFF
--- a/examples/03_Transfer_Learning.ipynb
+++ b/examples/03_Transfer_Learning.ipynb
@@ -262,7 +262,7 @@
    "source": [
     "## DFT -> CC Fine Tuning\n",
     "\n",
-    "Finally, we can fine tine a model that was pretrained on DFT data.\n",
+    "Finally, we can fine tune a model that was pretrained on DFT data.\n",
     "The model architecture remains unchanged for all 3 runs.\n",
     "However, for fine-tuning we need to specify the path to the base model and how to deal with its parameters.\n",
     "For each parameter group we can choose to freeze, to reset it or to keep training it.\n",

--- a/examples/03_Transfer_Learning.ipynb
+++ b/examples/03_Transfer_Learning.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Datasets computed at high levels of theory are expensive and thus, usually small. \n",
     "A model trained on this data might not be able to generalize well to unseen configurations.\n",
-    "Some times this can be remedied with transfer learning:\n",
+    "Sometimes this can be remedied with transfer learning:\n",
     "By first training a model on a lot of data from a less expensive level of theory, only small adjustments to the parameters are required to accurately reproduce the potential energy surface of a different level of theory.\n",
     "\n",
     "\n",

--- a/examples/03_Transfer_Learning.ipynb
+++ b/examples/03_Transfer_Learning.ipynb
@@ -17,7 +17,7 @@
     "For a demonstration of using transfer learning for learning on the fly, see the corresponding example from the [IPSuite documentation](https://ipsuite.readthedocs.io/en/latest/).\n",
     "\n",
     "\n",
-    "apax comes with discriminative transfer learning capabilities out of the box.\n",
+    "Apax comes with discriminative transfer learning capabilities out of the box.\n",
     "In this tutorial we are going to fine tune a model trained on benzene data at the DFT level of theory to CCSDT."
    ]
   },


### PR DESCRIPTION
Someone should look into the writing of the word `apax` and decide if they want to write it capitalized or not as there is currently no consistency.