### PR TITLE
fix apax calibrate metrics

### DIFF
--- a/apax/calibration.py
+++ b/apax/calibration.py
@@ -62,4 +62,4 @@ def compute_calibration_factors(
             Fpred, Fstd, Ftrue, criterion, optimizer_bounds=optimizer_bounds
         )
 
-    return e_factor, f_factor
+    return 1 / e_factor, 1 / f_factor

--- a/apax/nodes/model.py
+++ b/apax/nodes/model.py
@@ -272,8 +272,8 @@ class ApaxCalibrate(ApaxBase):
         )
 
         self.metrics = {
-            "e_factor": self.e_factor,
-            "f_factor": self.f_factor,
+            "e_factor": 1 / self.e_factor,
+            "f_factor": 1 / self.f_factor,
         }
 
     def get_calculator(self, **kwargs) -> ase.calculators.calculator.Calculator:

--- a/apax/nodes/model.py
+++ b/apax/nodes/model.py
@@ -272,8 +272,8 @@ class ApaxCalibrate(ApaxBase):
         )
 
         self.metrics = {
-            "e_factor": 1 / self.e_factor,
-            "f_factor": 1 / self.f_factor,
+            "e_factor": self.e_factor,
+            "f_factor": self.f_factor,
         }
 
     def get_calculator(self, **kwargs) -> ase.calculators.calculator.Calculator:


### PR DESCRIPTION
@M-R-Schaefer or would it be better to return the `1/e_factor` from `compute_calibration_factors` directly?