### PR TITLE
add `.paramter` to ApaxCalibrate node

### DIFF
--- a/apax/nodes/model.py
+++ b/apax/nodes/model.py
@@ -283,6 +283,10 @@ class ApaxCalibrate(ApaxBase):
     @property
     def model_directory(self):
         return self.model.model_directory
+        
+    @property
+    def parameter(self) -> dict:
+        return self.model.parameter
 
     def get_calculator(self, **kwargs):
         """Property to return a model specific ase calculator object.


### PR DESCRIPTION
To use the calibrated node e.g. in batchkernelselection, it needs to have the `.parameter` property.

Do we need to update the parameters with the calibration factors?