### PR TITLE
Refactor frames property for return znh5md.IO

### DIFF
--- a/apax/nodes/md.py
+++ b/apax/nodes/md.py
@@ -99,7 +99,6 @@ class ApaxJaxMD(zntrack.Node):
 
     @property
     def frames(self) -> znh5md.IO:
-
         @contextlib.contextmanager
         def _factory() -> typing.Callable[[], typing.ContextManager[h5py.File]]:
             if self.state.rev is None and self.state.remote is None:


### PR DESCRIPTION
Prior to this PR, when accessing `node.frames` the entire h5 file is loaded into memory.
The `znh5md.IO` file supports the same indexing like a list but without loading everything into memory.
Further, one can specify which parts are interesting

```py
io = node.frames
io.include=["position", "box"] # much faster than loading all calc results
io[:]
```