### PR TITLE
Agent CLI parsing

### DIFF
--- a/apax/cli/apax_app.py
+++ b/apax/cli/apax_app.py
@@ -27,8 +27,14 @@ template_app = typer.Typer(
     context_settings={"help_option_names": ["-h", "--help"]},
     help="Create configuration file templates.",
 )
+schema_app = typer.Typer(
+    pretty_exceptions_show_locals=False,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    help="Generate JSON schemata for train/md configs.",
+)
 app.add_typer(validate_app, name="validate")
 app.add_typer(template_app, name="template")
+app.add_typer(schema_app, name="schema")
 
 
 @app.command()
@@ -94,10 +100,110 @@ def docs():
     typer.launch("https://apax.readthedocs.io/en/latest/")
 
 
-@app.command()
-def schema():
+def _print_keywords_or_exit(schema, section):
+    """Print keywords using schema_navigation, exit on error."""
+    from apax.config.schema_navigation import print_keywords
+
+    defs = schema.get("$defs", {})
+    error = print_keywords(schema, section, defs)
+    if error:
+        console.print(error, style="red3")
+        raise typer.Exit(code=1)
+
+
+def _filter_schema_or_exit(schema, section):
+    """Filter schema using schema_navigation, exit on error."""
+    from apax.config.schema_navigation import filter_schema
+
+    node, error = filter_schema(schema, section)
+    if error:
+        console.print(error, style="red3")
+        raise typer.Exit(code=1)
+    return node
+
+
+@schema_app.command("train")
+def schema_train(
+    section: str = typer.Argument(
+        None,
+        help=(
+            "Dotted path to filter (e.g. 'model', 'model.gmnn',"
+            " 'model.gmnn.basis', 'optimizer'). Omit for the full schema."
+        ),
+    ),
+    keywords: bool = typer.Option(
+        False,
+        "--keywords",
+        help="Only list navigable subsection names at the given path.",
+    ),
+    flat: bool = typer.Option(
+        False,
+        "--flat",
+        help="List all parameters as a flat table with path, type, default, and description.",
+    ),
+):
     """
-    Generating JSON schemata for autocompletion of train/md inputs in VSCode.
+    Print the training config JSON schema to stdout.
+    """
+    from apax.config import Config
+
+    if flat:
+        from apax.config.flat_schema import print_flat
+
+        print_flat(Config)
+        return
+    schema = Config.model_json_schema()
+    if keywords:
+        _print_keywords_or_exit(schema, section)
+        return
+    if section:
+        schema = _filter_schema_or_exit(schema, section)
+    print(json.dumps(schema, indent=2))
+
+
+@schema_app.command("md")
+def schema_md(
+    section: str = typer.Argument(
+        None,
+        help=(
+            "Dotted path to filter (e.g. 'ensemble', 'ensemble.nvt',"
+            " 'constraints'). Omit for the full schema."
+        ),
+    ),
+    keywords: bool = typer.Option(
+        False,
+        "--keywords",
+        help="Only list navigable subsection names at the given path.",
+    ),
+    flat: bool = typer.Option(
+        False,
+        "--flat",
+        help="List all parameters as a flat table with path, type, default, and description.",
+    ),
+):
+    """
+    Print the MD config JSON schema to stdout.
+    """
+    from apax.config import MDConfig
+
+    if flat:
+        from apax.config.flat_schema import print_flat
+
+        print_flat(MDConfig)
+        return
+    schema = MDConfig.model_json_schema()
+    if keywords:
+        _print_keywords_or_exit(schema, section)
+        return
+    if section:
+        schema = _filter_schema_or_exit(schema, section)
+    print(json.dumps(schema, indent=2))
+
+
+@schema_app.command("vscode")
+def schema_vscode():
+    """
+    Generate JSON schema files under .vscode/ for YAML autocompletion.
     """
     console.print("Generating JSON schema")
     from apax.config import Config, MDConfig
@@ -156,10 +262,26 @@ def cleanup_error(e):
     return e_clean
 
 
+TEMPLATE_DATA_DEFAULTS = {
+    "directory": "/tmp/apax_validate",
+    "experiment": "placeholder",
+    "data_path": "/tmp/apax_validate/placeholder.extxyz",
+}
+
+
 @validate_app.command("train")
 def validate_train_config(
     config_path: Path = typer.Argument(
         ..., help="Configuration YAML file to be validated."
+    ),
+    template: bool = typer.Option(
+        False,
+        "--template",
+        help=(
+            "Validate as a zntrack/ipsuite template. Fills in dummy values for"
+            " directory, experiment, and data_path so configs that leave these"
+            " to be set at runtime can still be validated."
+        ),
     ),
 ):
     """
@@ -168,11 +290,18 @@ def validate_train_config(
     Parameters
     ----------
     config_path: Path to the training configuration file.
+    template: If True, fill in placeholder values for runtime fields.
     """
     from apax.config import Config
 
     with open(config_path, "r") as stream:
         user_config = yaml.safe_load(stream)
+
+    if template:
+        data = user_config.setdefault("data", {})
+        for key, default in TEMPLATE_DATA_DEFAULTS.items():
+            if key not in data or data[key] is None:
+                data[key] = default
 
     try:
         _ = Config.model_validate(user_config)

--- a/apax/cli/apax_app.py
+++ b/apax/cli/apax_app.py
@@ -13,25 +13,15 @@ from apax.cli import templates
 
 console = Console(highlight=False)
 
-app = typer.Typer(
-    context_settings={"help_option_names": ["-h", "--help"]},
-    pretty_exceptions_show_locals=False,
-)
-validate_app = typer.Typer(
+_TYPER_OPTS = dict(
     pretty_exceptions_show_locals=False,
     context_settings={"help_option_names": ["-h", "--help"]},
-    help="Validate training or MD config files.",
 )
-template_app = typer.Typer(
-    pretty_exceptions_show_locals=False,
-    context_settings={"help_option_names": ["-h", "--help"]},
-    help="Create configuration file templates.",
-)
-schema_app = typer.Typer(
-    pretty_exceptions_show_locals=False,
-    context_settings={"help_option_names": ["-h", "--help"]},
-    help="Generate JSON schemata for train/md configs.",
-)
+
+app = typer.Typer(**_TYPER_OPTS)
+validate_app = typer.Typer(**_TYPER_OPTS, help="Validate training or MD config files.")
+template_app = typer.Typer(**_TYPER_OPTS, help="Create configuration file templates.")
+schema_app = typer.Typer(**_TYPER_OPTS, help="Generate JSON schemata for train/md configs.")
 app.add_typer(validate_app, name="validate")
 app.add_typer(template_app, name="template")
 app.add_typer(schema_app, name="schema")
@@ -93,11 +83,12 @@ def eval(
 
 @app.command()
 def docs():
-    """
-    Opens the documentation website in your browser.
-    """
+    """Opens the documentation website in your browser."""
     console.print("Opening apax's docs at https://apax.readthedocs.io/en/latest/")
     typer.launch("https://apax.readthedocs.io/en/latest/")
+
+
+# --- Schema commands ---
 
 
 def _handle_schema(config_cls, section, keywords, flat):
@@ -175,9 +166,7 @@ def schema_md(
 
 @schema_app.command("vscode")
 def schema_vscode():
-    """
-    Generate JSON schema files under .vscode/ for YAML autocompletion.
-    """
+    """Generate JSON schema files under .vscode/ for YAML autocompletion."""
     console.print("Generating JSON schema")
     from apax.config import Config, MDConfig
 
@@ -185,57 +174,49 @@ def schema_vscode():
     vscode_path.mkdir(exist_ok=True)
 
     settings_path = vscode_path / "settings.json"
+    settings = json.loads(settings_path.read_text()) if settings_path.is_file() else {}
+    settings.setdefault("yaml.schemas", {})
 
-    if not settings_path.is_file():
-        with settings_path.open("w") as f:
-            json.dump({"yaml.schemas": {}}, f, indent=2)
+    for name, cls, globs in [
+        ("apaxtrain", Config, ["train*.yaml"]),
+        ("apaxmd", MDConfig, ["md*.yaml"]),
+    ]:
+        schema_path = vscode_path / f"{name}.schema.json"
+        settings["yaml.schemas"][schema_path.resolve().as_posix()] = globs
+        schema_path.write_text(json.dumps(cls.model_json_schema(), indent=2))
 
-    with settings_path.open("r") as f:
-        settings = json.load(f)
-
-    if "yaml.schemas" not in settings.keys():
-        settings["yaml.schemas"] = {}
-
-    train_schema = (vscode_path / "apaxtrain.schema.json").resolve().as_posix()
-    md_schema = (vscode_path / "apaxmd.schema.json").resolve().as_posix()
-
-    schemas = {train_schema: ["train*.yaml"], md_schema: ["md*.yaml"]}
-    settings["yaml.schemas"].update(schemas)
-
-    with settings_path.open("w") as f:
-        json.dump(settings, f, indent=2)
-
-    train_schema = Config.model_json_schema()
-    md_schema = MDConfig.model_json_schema()
-    with (vscode_path / "apaxtrain.schema.json").open("w") as f:
-        json.dump(train_schema, f, indent=2)
-
-    with (vscode_path / "apaxmd.schema.json").open("w") as f:
-        json.dump(md_schema, f, indent=2)
+    settings_path.write_text(json.dumps(settings, indent=2))
 
 
-def format_error(error):
-    input_type = type(error["input"]).__name__
-    loc = ".".join(error["loc"])
-    error_msg = error["msg"]
-    msg = f"{loc}\n  {error_msg}\n  input_type: {input_type}"
-    if type(error["input"]) not in [dict, list]:
-        field_input = error["input"]
-        msg += f"\n  input: {field_input}"
-    msg += "\n"
-    return msg
+# --- Validation commands ---
 
 
-def cleanup_error(e):
-    e_clean = []
+def _format_errors(e):
+    """Format pydantic ValidationError into readable lines."""
+    parts = []
     for error in e.errors():
-        error.pop("url")
-        e_clean.append(format_error(error))
-    e_clean = "".join(e_clean)
-    return e_clean
+        loc = ".".join(str(x) for x in error["loc"])
+        msg = f"{loc}\n  {error['msg']}\n  input_type: {type(error['input']).__name__}"
+        if type(error["input"]) not in (dict, list):
+            msg += f"\n  input: {error['input']}"
+        parts.append(msg + "\n")
+    return "".join(parts)
 
 
-TEMPLATE_DATA_DEFAULTS = {
+def _validate_config(config_cls, config_path, user_config, label):
+    """Validate a config dict and print result."""
+    try:
+        config_cls.model_validate(user_config)
+    except ValidationError as e:
+        print(f"{e.error_count()} validation errors for config")
+        print(_format_errors(e))
+        console.print("Configuration Invalid!", style="red3")
+        raise typer.Exit(code=1)
+    console.print("Success!", style="green3")
+    console.print(f"{config_path} is a valid {label} config.")
+
+
+_TEMPLATE_DATA_DEFAULTS = {
     "directory": "/tmp/apax_validate",
     "experiment": "placeholder",
     "data_path": "/tmp/apax_validate/placeholder.extxyz",
@@ -257,14 +238,7 @@ def validate_train_config(
         ),
     ),
 ):
-    """
-    Validates a training configuration file.
-
-    Parameters
-    ----------
-    config_path: Path to the training configuration file.
-    template: If True, fill in placeholder values for runtime fields.
-    """
+    """Validates a training configuration file."""
     from apax.config import Config
 
     with open(config_path, "r") as stream:
@@ -272,20 +246,11 @@ def validate_train_config(
 
     if template:
         data = user_config.setdefault("data", {})
-        for key, default in TEMPLATE_DATA_DEFAULTS.items():
+        for key, default in _TEMPLATE_DATA_DEFAULTS.items():
             if key not in data or data[key] is None:
                 data[key] = default
 
-    try:
-        _ = Config.model_validate(user_config)
-    except ValidationError as e:
-        print(f"{e.error_count()} validation errors for config")
-        print(cleanup_error(e))
-        console.print("Configuration Invalid!", style="red3")
-        raise typer.Exit(code=1)
-    else:
-        console.print("Success!", style="green3")
-        console.print(f"{config_path} is a valid training config.")
+    _validate_config(Config, config_path, user_config, "training")
 
 
 @validate_app.command("md")
@@ -294,27 +259,16 @@ def validate_md_config(
         ..., help="Configuration YAML file to be validated."
     ),
 ):
-    """
-    Validates a molecular dynamics configuration file.
-
-    Parameters
-    ----------
-    config_path: Path to the molecular dynamics configuration file.
-    """
+    """Validates a molecular dynamics configuration file."""
     from apax.config import MDConfig
 
     with open(config_path, "r") as stream:
         user_config = yaml.safe_load(stream)
 
-    try:
-        _ = MDConfig.model_validate(user_config)
-    except ValidationError as e:
-        print(e)
-        console.print("Configuration Invalid!", style="red3")
-        raise typer.Exit(code=1)
-    else:
-        console.print("Success!", style="green3")
-        console.print(f"{config_path} is a valid MD config.")
+    _validate_config(MDConfig, config_path, user_config, "MD")
+
+
+# --- Other commands ---
 
 
 @app.command("visualize")
@@ -331,10 +285,6 @@ def visualize_model(
     Visualize a model based on a configuration file.
     A CO molecule is taken as sample input (influences number of atoms,
     number of species is set to 10).
-
-    Parameters
-    ----------
-    config_path: Path to the training configuration file.
     """
     import jax
 
@@ -358,47 +308,31 @@ def visualize_model(
     print(model.tabulate(jax.random.PRNGKey(0), R, Z, idx, box, offsets))
 
 
+def _write_template(template_file, config_path):
+    """Write a template file, exiting if one already exists."""
+    if Path(config_path).is_file():
+        console.print("There is already a config file in the working directory.")
+        sys.exit(1)
+    content = pkg_resources.read_text(templates, template_file)
+    with open(config_path, "w") as f:
+        f.write(content)
+
+
 @template_app.command("train")
 def template_train_config(
     full: bool = typer.Option(False, help="Use all input options."),
 ):
-    """
-    Creates a training input template in the current working directory.
-    """
+    """Creates a training input template in the current working directory."""
     if full:
-        template_file = "train_config_full.yaml"
-        config_path = "config_full.yaml"
+        _write_template("train_config_full.yaml", "config_full.yaml")
     else:
-        template_file = "train_config_minimal.yaml"
-        config_path = "config.yaml"
-
-    template_content = pkg_resources.read_text(templates, template_file)
-
-    if Path(config_path).is_file():
-        console.print("There is already a config file in the working directory.")
-        sys.exit(1)
-    else:
-        with open(config_path, "w") as config:
-            config.write(template_content)
+        _write_template("train_config_minimal.yaml", "config.yaml")
 
 
 @template_app.command("md")
 def template_md_config():
-    """
-    Creates a training input template in the current working directory.
-    """
-
-    template_file = "md_config_minimal.yaml"
-    config_path = "md_config.yaml"
-
-    template_content = pkg_resources.read_text(templates, template_file)
-
-    if Path(config_path).is_file():
-        console.print("There is already a config file in the working directory.")
-        sys.exit(1)
-    else:
-        with open(config_path, "w") as config:
-            config.write(template_content)
+    """Creates an MD input template in the current working directory."""
+    _write_template("md_config_minimal.yaml", "md_config.yaml")
 
 
 def version_callback(value: bool) -> None:
@@ -414,5 +348,4 @@ def main(
         None, "--version", "-V", callback=version_callback, is_eager=True
     ),
 ):
-    # Taken from https://github.com/zincware/dask4dvc/blob/main/dask4dvc/cli/main.py
     _ = version

--- a/apax/cli/apax_app.py
+++ b/apax/cli/apax_app.py
@@ -100,26 +100,29 @@ def docs():
     typer.launch("https://apax.readthedocs.io/en/latest/")
 
 
-def _print_keywords_or_exit(schema, section):
-    """Print keywords using schema_navigation, exit on error."""
-    from apax.config.schema_navigation import print_keywords
+def _handle_schema(config_cls, section, keywords, flat):
+    """Shared logic for schema train/md commands."""
+    if flat:
+        from apax.config.flat_schema import print_flat
 
-    defs = schema.get("$defs", {})
-    error = print_keywords(schema, section, defs)
-    if error:
-        console.print(error, style="red3")
-        raise typer.Exit(code=1)
+        print_flat(config_cls)
+        return
+    from apax.config.schema_navigation import filter_schema, print_keywords
 
-
-def _filter_schema_or_exit(schema, section):
-    """Filter schema using schema_navigation, exit on error."""
-    from apax.config.schema_navigation import filter_schema
-
-    node, error = filter_schema(schema, section)
-    if error:
-        console.print(error, style="red3")
-        raise typer.Exit(code=1)
-    return node
+    schema = config_cls.model_json_schema()
+    if keywords:
+        error = print_keywords(schema, section)
+        if error:
+            console.print(error, style="red3")
+            raise typer.Exit(code=1)
+        return
+    if section:
+        node, error = filter_schema(schema, section)
+        if error:
+            console.print(error, style="red3")
+            raise typer.Exit(code=1)
+        schema = node
+    print(json.dumps(schema, indent=2))
 
 
 @schema_app.command("train")
@@ -132,33 +135,18 @@ def schema_train(
         ),
     ),
     keywords: bool = typer.Option(
-        False,
-        "--keywords",
+        False, "--keywords",
         help="Only list navigable subsection names at the given path.",
     ),
     flat: bool = typer.Option(
-        False,
-        "--flat",
+        False, "--flat",
         help="List all parameters as a flat table with path, type, default, and description.",
     ),
 ):
-    """
-    Print the training config JSON schema to stdout.
-    """
+    """Print the training config JSON schema to stdout."""
     from apax.config import Config
 
-    if flat:
-        from apax.config.flat_schema import print_flat
-
-        print_flat(Config)
-        return
-    schema = Config.model_json_schema()
-    if keywords:
-        _print_keywords_or_exit(schema, section)
-        return
-    if section:
-        schema = _filter_schema_or_exit(schema, section)
-    print(json.dumps(schema, indent=2))
+    _handle_schema(Config, section, keywords, flat)
 
 
 @schema_app.command("md")
@@ -171,33 +159,18 @@ def schema_md(
         ),
     ),
     keywords: bool = typer.Option(
-        False,
-        "--keywords",
+        False, "--keywords",
         help="Only list navigable subsection names at the given path.",
     ),
     flat: bool = typer.Option(
-        False,
-        "--flat",
+        False, "--flat",
         help="List all parameters as a flat table with path, type, default, and description.",
     ),
 ):
-    """
-    Print the MD config JSON schema to stdout.
-    """
+    """Print the MD config JSON schema to stdout."""
     from apax.config import MDConfig
 
-    if flat:
-        from apax.config.flat_schema import print_flat
-
-        print_flat(MDConfig)
-        return
-    schema = MDConfig.model_json_schema()
-    if keywords:
-        _print_keywords_or_exit(schema, section)
-        return
-    if section:
-        schema = _filter_schema_or_exit(schema, section)
-    print(json.dumps(schema, indent=2))
+    _handle_schema(MDConfig, section, keywords, flat)
 
 
 @schema_app.command("vscode")

--- a/apax/cli/apax_app.py
+++ b/apax/cli/apax_app.py
@@ -20,7 +20,9 @@ _TYPER_OPTS = {
 app = typer.Typer(**_TYPER_OPTS)
 validate_app = typer.Typer(**_TYPER_OPTS, help="Validate training or MD config files.")
 template_app = typer.Typer(**_TYPER_OPTS, help="Create configuration file templates.")
-schema_app = typer.Typer(**_TYPER_OPTS, help="Generate JSON schemata for train/md configs.")
+schema_app = typer.Typer(
+    **_TYPER_OPTS, help="Generate JSON schemata for train/md configs."
+)
 app.add_typer(validate_app, name="validate")
 app.add_typer(template_app, name="template")
 app.add_typer(schema_app, name="schema")
@@ -125,11 +127,13 @@ def schema_train(
         ),
     ),
     keywords: bool = typer.Option(
-        False, "--keywords",
+        False,
+        "--keywords",
         help="Only list navigable subsection names at the given path.",
     ),
     flat: bool = typer.Option(
-        False, "--flat",
+        False,
+        "--flat",
         help="List all parameters as a flat table with path, type, default, and description.",
     ),
 ):
@@ -149,11 +153,13 @@ def schema_md(
         ),
     ),
     keywords: bool = typer.Option(
-        False, "--keywords",
+        False,
+        "--keywords",
         help="Only list navigable subsection names at the given path.",
     ),
     flat: bool = typer.Option(
-        False, "--flat",
+        False,
+        "--flat",
         help="List all parameters as a flat table with path, type, default, and description.",
     ),
 ):

--- a/apax/cli/apax_app.py
+++ b/apax/cli/apax_app.py
@@ -12,10 +12,10 @@ from apax.cli import templates
 
 console = Console(highlight=False)
 
-_TYPER_OPTS = dict(
-    pretty_exceptions_show_locals=False,
-    context_settings={"help_option_names": ["-h", "--help"]},
-)
+_TYPER_OPTS = {
+    "pretty_exceptions_show_locals": False,
+    "context_settings": {"help_option_names": ["-h", "--help"]},
+}
 
 app = typer.Typer(**_TYPER_OPTS)
 validate_app = typer.Typer(**_TYPER_OPTS, help="Validate training or MD config files.")

--- a/apax/cli/templates/train_config_full.yaml
+++ b/apax/cli/templates/train_config_full.yaml
@@ -76,7 +76,7 @@ loss:
   atoms_exponent: 1
 - name: forces
   loss_type: mse
-  weight: 4.0
+  weight: 1.0
   atoms_exponent: 1
 
 metrics:

--- a/apax/cli/templates/train_config_minimal.yaml
+++ b/apax/cli/templates/train_config_minimal.yaml
@@ -20,4 +20,4 @@ metrics:
 loss:
   - name: energy
   - name: forces
-    weight: 4.0
+    weight: 1.0

--- a/apax/config/flat_schema.py
+++ b/apax/config/flat_schema.py
@@ -8,8 +8,13 @@ from typing import Literal, Union, get_args, get_origin
 from pydantic import BaseModel
 
 _TYPE_MAP = {
-    int: "integer", float: "number", str: "string", bool: "boolean",
-    dict: "object", list: "array", pathlib.Path: "string",
+    int: "integer",
+    float: "number",
+    str: "string",
+    bool: "boolean",
+    dict: "object",
+    list: "array",
+    pathlib.Path: "string",
 }
 
 
@@ -103,7 +108,9 @@ def _shared_base(variants):
     """Most specific common BaseModel ancestor (excluding BaseModel and variants themselves)."""
     if len(variants) < 2:
         return None
-    mros = [[b for b in v.__mro__ if _is_model(b) and b is not BaseModel] for v in variants]
+    mros = [
+        [b for b in v.__mro__ if _is_model(b) and b is not BaseModel] for v in variants
+    ]
     common = set(mros[0]).intersection(*mros[1:]) - set(variants)
     return min(common, key=lambda c: mros[0].index(c)) if common else None
 
@@ -145,7 +152,9 @@ def _flatten(cls, prefix="", _seen=None, exclude=frozenset()):
                     rows.extend(_flatten(base, base_path, _seen.copy()))
                 for m in models:
                     vname = _variant_name(m) or m.__name__
-                    rows.extend(_flatten(m, f"{base_path}.{vname}", _seen.copy(), exclude=shared))
+                    rows.extend(
+                        _flatten(m, f"{base_path}.{vname}", _seen.copy(), exclude=shared)
+                    )
             else:
                 rows.extend(_flatten(models[0], base_path, _seen.copy()))
         else:

--- a/apax/config/flat_schema.py
+++ b/apax/config/flat_schema.py
@@ -7,6 +7,11 @@ from typing import Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
 
+_TYPE_MAP = {
+    int: "integer", float: "number", str: "string", bool: "boolean",
+    dict: "object", list: "array", pathlib.Path: "string",
+}
+
 
 def _unwrap(annotation):
     """Strip Annotated wrapper."""
@@ -15,6 +20,10 @@ def _unwrap(annotation):
 
 def _is_model(cls):
     return isinstance(cls, type) and issubclass(cls, BaseModel)
+
+
+def _is_union(annotation):
+    return get_origin(annotation) is Union or isinstance(annotation, _types.UnionType)
 
 
 def _classify(annotation):
@@ -27,8 +36,7 @@ def _classify(annotation):
         if annotation is None:
             return [], True, False
 
-    is_union = get_origin(annotation) is Union or isinstance(annotation, _types.UnionType)
-    if is_union:
+    if _is_union(annotation):
         args = get_args(annotation)
         return [a for a in args if _is_model(a)], is_list, type(None) in args
     if _is_model(annotation):
@@ -56,9 +64,7 @@ def _type_str(annotation):
     if origin is Literal:
         vals = get_args(annotation)
         return repr(vals[0]) if len(vals) == 1 else "|".join(str(v) for v in vals)
-
-    is_union = origin is Union or isinstance(annotation, _types.UnionType)
-    if is_union:
+    if _is_union(annotation):
         args = get_args(annotation)
         has_none = type(None) in args
         members = [a for a in args if a is not type(None)]
@@ -68,14 +74,10 @@ def _type_str(annotation):
         if non_model:
             return "|".join(_type_str(m) for m in non_model)
 
-    _MAP = {
-        int: "integer", float: "number", str: "string", bool: "boolean",
-        dict: "object", list: "array", pathlib.Path: "string",
-    }
-    if annotation in _MAP:
-        return _MAP[annotation]
+    if annotation in _TYPE_MAP:
+        return _TYPE_MAP[annotation]
     if isinstance(annotation, type):
-        for base, name in _MAP.items():
+        for base, name in _TYPE_MAP.items():
             if issubclass(annotation, base):
                 return name
     return str(annotation)

--- a/apax/config/flat_schema.py
+++ b/apax/config/flat_schema.py
@@ -1,122 +1,87 @@
-"""Generate a flat parameter table by introspecting pydantic model classes directly.
-
-This avoids the complexity of walking JSON schema with $ref resolution,
-oneOf/anyOf handling, etc. Instead, it uses the class hierarchy that already
-encodes inheritance (shared fields), Union types (variants), and Optional
-(optional sections).
-"""
+"""Flat parameter table from pydantic model introspection."""
 
 import json
-from typing import Optional, Union, get_args, get_origin
+import pathlib
+import types as _types
+from typing import Literal, Union, get_args, get_origin
 
 from pydantic import BaseModel
-from pydantic.fields import FieldInfo
 
 
-def _is_union(annotation) -> bool:
-    return get_origin(annotation) is Union
+def _unwrap(annotation):
+    """Strip Annotated wrapper."""
+    return get_args(annotation)[0] if hasattr(annotation, "__metadata__") else annotation
 
 
-def _is_optional(annotation) -> bool:
-    """Check if a type annotation is Optional[X] (i.e. Union[X, None])."""
-    if not _is_union(annotation):
-        return False
-    return type(None) in get_args(annotation)
-
-
-def _get_union_members(annotation) -> list[type]:
-    """Get non-None members of a Union type."""
-    return [a for a in get_args(annotation) if a is not type(None)]
-
-
-def _is_model(cls) -> bool:
+def _is_model(cls):
     return isinstance(cls, type) and issubclass(cls, BaseModel)
 
 
-def _is_list_of(annotation):
-    """If annotation is list[X], return X. Otherwise return None."""
-    origin = get_origin(annotation)
-    if origin is list:
+def _classify(annotation):
+    """Classify a field annotation into (model_classes, is_list, is_optional)."""
+    annotation = _unwrap(annotation)
+    is_list = get_origin(annotation) is list
+    if is_list:
         args = get_args(annotation)
-        return args[0] if args else None
-    return None
+        annotation = _unwrap(args[0]) if args else None
+        if annotation is None:
+            return [], True, False
+
+    is_union = get_origin(annotation) is Union or isinstance(annotation, _types.UnionType)
+    if is_union:
+        args = get_args(annotation)
+        return [a for a in args if _is_model(a)], is_list, type(None) in args
+    if _is_model(annotation):
+        return [annotation], is_list, False
+    return [], is_list, False
 
 
-def _get_variant_name(model_cls: type[BaseModel]) -> Optional[str]:
-    """Extract the variant name from a Literal[...] 'name' or 'kind' field."""
-    for disc_field in ("name", "kind", "processing"):
-        if disc_field in model_cls.model_fields:
-            info = model_cls.model_fields[disc_field]
-            args = get_args(info.annotation)
-            # Literal["gmnn"] -> args = ("gmnn",)
+def _variant_name(model_cls):
+    """Extract variant name from a Literal 'name'/'kind'/'processing' field."""
+    for key in ("name", "kind", "processing"):
+        if key in model_cls.model_fields:
+            args = get_args(model_cls.model_fields[key].annotation)
             if args and all(isinstance(a, str) for a in args):
                 return args[0]
     return None
 
 
-def _unwrap_annotated(annotation):
-    """Strip typing.Annotated wrapper, returning the base type."""
-    if hasattr(annotation, "__metadata__"):  # Annotated[X, ...]
-        return get_args(annotation)[0]
-    return annotation
-
-
-def _type_str(annotation) -> str:
-    """Human-readable type string from a type annotation."""
-    from typing import Literal
-
-    annotation = _unwrap_annotated(annotation)
+def _type_str(annotation):
+    """Human-readable type string."""
+    annotation = _unwrap(annotation)
     origin = get_origin(annotation)
 
     if origin is list:
         return "array"
-
-    if get_origin(annotation) is Literal:
+    if origin is Literal:
         vals = get_args(annotation)
-        if len(vals) == 1:
-            return repr(vals[0])
-        return "|".join(str(v) for v in vals)
+        return repr(vals[0]) if len(vals) == 1 else "|".join(str(v) for v in vals)
 
-    # Optional[X] -> type_str(X)|null
-    if _is_optional(annotation):
-        members = _get_union_members(annotation)
-        if len(members) == 1:
+    is_union = origin is Union or isinstance(annotation, _types.UnionType)
+    if is_union:
+        args = get_args(annotation)
+        has_none = type(None) in args
+        members = [a for a in args if a is not type(None)]
+        if has_none and len(members) == 1:
             return f"{_type_str(members[0])}|null"
-
-    # Union of non-model types (e.g. str | Path)
-    if _is_union(annotation):
-        members = [a for a in get_args(annotation) if a is not type(None)]
         non_model = [m for m in members if not _is_model(m)]
         if non_model:
             return "|".join(_type_str(m) for m in non_model)
 
-    # Simple types
-    import pathlib
-
-    type_map = {
+    _MAP = {
         int: "integer", float: "number", str: "string", bool: "boolean",
         dict: "object", list: "array", pathlib.Path: "string",
     }
-    if annotation in type_map:
-        return type_map[annotation]
-
-    # Pydantic constrained types (PositiveInt, NonNegativeFloat, etc.)
+    if annotation in _MAP:
+        return _MAP[annotation]
     if isinstance(annotation, type):
-        for base, name in type_map.items():
+        for base, name in _MAP.items():
             if issubclass(annotation, base):
                 return name
-
-    # types.UnionType (Python 3.10+ `X | Y` syntax)
-    import types as _types
-
-    if isinstance(annotation, _types.UnionType):
-        members = [a for a in get_args(annotation) if a is not type(None)]
-        return "|".join(_type_str(m) for m in members)
-
     return str(annotation)
 
 
-def _default_str(field_info: FieldInfo) -> str:
+def _default_str(field_info):
     """Compact default value string."""
     if field_info.is_required():
         return "REQUIRED"
@@ -124,7 +89,7 @@ def _default_str(field_info: FieldInfo) -> str:
     if val is None:
         return "null"
     if _is_model(type(val)):
-        return str(type(val).__name__)
+        return type(val).__name__
     try:
         s = json.dumps(val)
     except (TypeError, ValueError):
@@ -132,169 +97,78 @@ def _default_str(field_info: FieldInfo) -> str:
     return s[:30] + "..." if len(s) > 30 else s
 
 
-def _description(field_info: FieldInfo) -> str:
-    """First line of description, truncated."""
-    desc = field_info.description or ""
-    return desc.split("\n")[0][:60]
-
-
-def _find_shared_base(variants: list[type[BaseModel]]) -> Optional[type[BaseModel]]:
-    """Find the common base class that holds shared fields (if any).
-
-    Returns the most specific common ancestor that is not BaseModel itself.
-    """
-    if not variants:
+def _shared_base(variants):
+    """Most specific common BaseModel ancestor (excluding BaseModel and variants themselves)."""
+    if len(variants) < 2:
         return None
-    bases_per_variant = []
-    for v in variants:
-        bases_per_variant.append(
-            [b for b in v.__mro__ if _is_model(b) and b is not BaseModel]
-        )
-    # Intersect MROs
-    common = set(bases_per_variant[0])
-    for bases in bases_per_variant[1:]:
-        common &= set(bases)
-    # Remove the variant classes themselves
-    common -= set(variants)
-    if not common:
-        return None
-    # Pick the most specific (closest to variants in MRO)
-    # Sort by MRO position of first variant
-    first_mro = bases_per_variant[0]
-    common_sorted = sorted(common, key=lambda c: first_mro.index(c))
-    return common_sorted[0]
+    mros = [[b for b in v.__mro__ if _is_model(b) and b is not BaseModel] for v in variants]
+    common = set(mros[0]).intersection(*mros[1:]) - set(variants)
+    return min(common, key=lambda c: mros[0].index(c)) if common else None
 
 
-def _flatten_model(
-    model_cls: type[BaseModel],
-    prefix: str = "",
-    _seen: set | None = None,
-    exclude_fields: set[str] | None = None,
-) -> list[tuple[str, str, str, str, bool]]:
-    """Flatten a pydantic model into (path, type, default, description, is_section) rows."""
+def _flatten(cls, prefix="", _seen=None, exclude=frozenset()):
+    """Recursively flatten a pydantic model into (path, type, default, desc, is_section) rows."""
     if _seen is None:
         _seen = set()
-    if exclude_fields is None:
-        exclude_fields = set()
-
-    if model_cls in _seen:
+    if cls in _seen:
         return []
-    _seen.add(model_cls)
-
+    _seen.add(cls)
     rows = []
 
-    for field_name, field_info in model_cls.model_fields.items():
-        if field_name in exclude_fields:
+    for field_name, info in cls.model_fields.items():
+        if field_name in exclude:
             continue
-
         path = f"{prefix}.{field_name}" if prefix else field_name
-        annotation = _unwrap_annotated(field_info.annotation)
+        models, is_list, is_optional = _classify(info.annotation)
 
-        # --- Union of model classes (discriminated union) ---
-        if _is_union(annotation):
-            members = _get_union_members(annotation)
-            model_members = [m for m in members if _is_model(m)]
+        if models:
+            base_path = f"{path}[]" if is_list else path
 
-            if len(model_members) > 1:
-                # Discriminated union
-                optional = _is_optional(annotation)
-                names = [_get_variant_name(m) or m.__name__ for m in model_members]
-                info_parts = []
-                if optional:
-                    info_parts.append("optional")
-                info_parts.append(f"default: {_default_str(field_info)}")
-                info = ", ".join(info_parts)
-                rows.append((path, f"[{info}]", "", f"variants: {', '.join(names)}", True))
+            # Emit section header when structure is non-trivial
+            if len(models) > 1 or is_list or is_optional:
+                parts = []
+                if is_list:
+                    parts.append("list")
+                if is_optional:
+                    parts.append("optional")
+                parts.append(f"default: {_default_str(info)}")
+                names = [_variant_name(m) or m.__name__ for m in models]
+                desc = f"variants: {', '.join(names)}" if len(models) > 1 else ""
+                rows.append((base_path, f"[{', '.join(parts)}]", "", desc, True))
 
-                # Find shared base and emit shared fields once
-                shared_base = _find_shared_base(model_members)
-                if shared_base:
-                    shared_fields = set(shared_base.model_fields.keys())
-                    rows.extend(_flatten_model(shared_base, path, _seen.copy(), set()))
-                else:
-                    shared_fields = set()
-
-                # Emit variant-specific fields
-                for m in model_members:
-                    vname = _get_variant_name(m) or m.__name__
-                    vpath = f"{path}.{vname}"
-                    rows.extend(
-                        _flatten_model(m, vpath, _seen.copy(), exclude_fields=shared_fields)
-                    )
-                continue
-
-            elif len(model_members) == 1:
-                # Optional[SomeModel] — single optional section
-                m = model_members[0]
-                optional = _is_optional(annotation)
-                if optional:
-                    rows.append((path, f"[optional, default: {_default_str(field_info)}]", "", "", True))
-                rows.extend(_flatten_model(m, path, _seen.copy()))
-                continue
-
-        # --- List of models ---
-        item_type = _is_list_of(annotation)
-        if item_type is not None:
-            actual_item = _unwrap_annotated(item_type)
-
-            if _is_union(actual_item):
-                members = _get_union_members(actual_item)
-                model_members = [m for m in members if _is_model(m)]
-            elif _is_model(actual_item):
-                model_members = [actual_item]
+            if len(models) > 1:
+                base = _shared_base(models)
+                shared = set(base.model_fields.keys()) if base else set()
+                if base:
+                    rows.extend(_flatten(base, base_path, _seen.copy()))
+                for m in models:
+                    vname = _variant_name(m) or m.__name__
+                    rows.extend(_flatten(m, f"{base_path}.{vname}", _seen.copy(), exclude=shared))
             else:
-                model_members = []
+                rows.extend(_flatten(models[0], base_path, _seen.copy()))
+        else:
+            ann = _unwrap(info.annotation)
+            desc = (info.description or "").split("\n")[0][:60]
+            rows.append((path, _type_str(ann), _default_str(info), desc, False))
 
-            if model_members:
-                names = [_get_variant_name(m) or m.__name__ for m in model_members]
-                desc = f"variants: {', '.join(names)}" if len(model_members) > 1 else ""
-                rows.append((f"{path}[]", f"[list, default: {_default_str(field_info)}]", "", desc, True))
-
-                if len(model_members) > 1:
-                    shared_base = _find_shared_base(model_members)
-                    shared_fields = set(shared_base.model_fields.keys()) if shared_base else set()
-                    if shared_base:
-                        rows.extend(_flatten_model(shared_base, f"{path}[]", _seen.copy(), set()))
-                    for m in model_members:
-                        vname = _get_variant_name(m) or m.__name__
-                        rows.extend(
-                            _flatten_model(m, f"{path}[].{vname}", _seen.copy(), exclude_fields=shared_fields)
-                        )
-                else:
-                    rows.extend(_flatten_model(model_members[0], f"{path}[]", _seen.copy()))
-                continue
-
-        # --- Nested single model ---
-        if _is_model(annotation):
-            rows.extend(_flatten_model(annotation, path, _seen.copy()))
-            continue
-
-        # --- Leaf field ---
-        rows.append((path, _type_str(annotation), _default_str(field_info), _description(field_info), False))
-
-    _seen.discard(model_cls)
+    _seen.discard(cls)
     return rows
 
 
-def print_flat(model_cls: type[BaseModel]):
-    """Print all parameters of a pydantic config as a flat table."""
-    rows = _flatten_model(model_cls)
+def print_flat(model_cls):
+    """Print all parameters as a flat table."""
+    rows = _flatten(model_cls)
     if not rows:
         return
-    leaf_rows = [r for r in rows if not r[4]]
-    if leaf_rows:
-        w_path = max(len(r[0]) for r in leaf_rows)
-        w_type = max(len(r[1]) for r in leaf_rows)
-        w_default = max(len(r[2]) for r in leaf_rows)
-    else:
-        w_path = w_type = w_default = 10
-    for path, type_str, default_str, desc, is_section in rows:
+    leaves = [r for r in rows if not r[4]]
+    wp = max((len(r[0]) for r in leaves), default=10)
+    wt = max((len(r[1]) for r in leaves), default=10)
+    wd = max((len(r[2]) for r in leaves), default=10)
+    for path, typ, default, desc, is_section in rows:
         if is_section:
-            line = f"\n{path:<{w_path}}  {type_str}"
-            if desc:
-                line += f"  {desc}"
+            line = f"\n{path:<{wp}}  {typ}"
         else:
-            line = f"{path:<{w_path}}  {type_str:<{w_type}}  {default_str:<{w_default}}"
-            if desc:
-                line += f"  {desc}"
+            line = f"{path:<{wp}}  {typ:<{wt}}  {default:<{wd}}"
+        if desc:
+            line += f"  {desc}"
         print(line)

--- a/apax/config/flat_schema.py
+++ b/apax/config/flat_schema.py
@@ -1,0 +1,300 @@
+"""Generate a flat parameter table by introspecting pydantic model classes directly.
+
+This avoids the complexity of walking JSON schema with $ref resolution,
+oneOf/anyOf handling, etc. Instead, it uses the class hierarchy that already
+encodes inheritance (shared fields), Union types (variants), and Optional
+(optional sections).
+"""
+
+import json
+from typing import Optional, Union, get_args, get_origin
+
+from pydantic import BaseModel
+from pydantic.fields import FieldInfo
+
+
+def _is_union(annotation) -> bool:
+    return get_origin(annotation) is Union
+
+
+def _is_optional(annotation) -> bool:
+    """Check if a type annotation is Optional[X] (i.e. Union[X, None])."""
+    if not _is_union(annotation):
+        return False
+    return type(None) in get_args(annotation)
+
+
+def _get_union_members(annotation) -> list[type]:
+    """Get non-None members of a Union type."""
+    return [a for a in get_args(annotation) if a is not type(None)]
+
+
+def _is_model(cls) -> bool:
+    return isinstance(cls, type) and issubclass(cls, BaseModel)
+
+
+def _is_list_of(annotation):
+    """If annotation is list[X], return X. Otherwise return None."""
+    origin = get_origin(annotation)
+    if origin is list:
+        args = get_args(annotation)
+        return args[0] if args else None
+    return None
+
+
+def _get_variant_name(model_cls: type[BaseModel]) -> Optional[str]:
+    """Extract the variant name from a Literal[...] 'name' or 'kind' field."""
+    for disc_field in ("name", "kind", "processing"):
+        if disc_field in model_cls.model_fields:
+            info = model_cls.model_fields[disc_field]
+            args = get_args(info.annotation)
+            # Literal["gmnn"] -> args = ("gmnn",)
+            if args and all(isinstance(a, str) for a in args):
+                return args[0]
+    return None
+
+
+def _unwrap_annotated(annotation):
+    """Strip typing.Annotated wrapper, returning the base type."""
+    if hasattr(annotation, "__metadata__"):  # Annotated[X, ...]
+        return get_args(annotation)[0]
+    return annotation
+
+
+def _type_str(annotation) -> str:
+    """Human-readable type string from a type annotation."""
+    from typing import Literal
+
+    annotation = _unwrap_annotated(annotation)
+    origin = get_origin(annotation)
+
+    if origin is list:
+        return "array"
+
+    if get_origin(annotation) is Literal:
+        vals = get_args(annotation)
+        if len(vals) == 1:
+            return repr(vals[0])
+        return "|".join(str(v) for v in vals)
+
+    # Optional[X] -> type_str(X)|null
+    if _is_optional(annotation):
+        members = _get_union_members(annotation)
+        if len(members) == 1:
+            return f"{_type_str(members[0])}|null"
+
+    # Union of non-model types (e.g. str | Path)
+    if _is_union(annotation):
+        members = [a for a in get_args(annotation) if a is not type(None)]
+        non_model = [m for m in members if not _is_model(m)]
+        if non_model:
+            return "|".join(_type_str(m) for m in non_model)
+
+    # Simple types
+    import pathlib
+
+    type_map = {
+        int: "integer", float: "number", str: "string", bool: "boolean",
+        dict: "object", list: "array", pathlib.Path: "string",
+    }
+    if annotation in type_map:
+        return type_map[annotation]
+
+    # Pydantic constrained types (PositiveInt, NonNegativeFloat, etc.)
+    if isinstance(annotation, type):
+        for base, name in type_map.items():
+            if issubclass(annotation, base):
+                return name
+
+    # types.UnionType (Python 3.10+ `X | Y` syntax)
+    import types as _types
+
+    if isinstance(annotation, _types.UnionType):
+        members = [a for a in get_args(annotation) if a is not type(None)]
+        return "|".join(_type_str(m) for m in members)
+
+    return str(annotation)
+
+
+def _default_str(field_info: FieldInfo) -> str:
+    """Compact default value string."""
+    if field_info.is_required():
+        return "REQUIRED"
+    val = field_info.default
+    if val is None:
+        return "null"
+    if _is_model(type(val)):
+        return str(type(val).__name__)
+    try:
+        s = json.dumps(val)
+    except (TypeError, ValueError):
+        s = repr(val)
+    return s[:30] + "..." if len(s) > 30 else s
+
+
+def _description(field_info: FieldInfo) -> str:
+    """First line of description, truncated."""
+    desc = field_info.description or ""
+    return desc.split("\n")[0][:60]
+
+
+def _find_shared_base(variants: list[type[BaseModel]]) -> Optional[type[BaseModel]]:
+    """Find the common base class that holds shared fields (if any).
+
+    Returns the most specific common ancestor that is not BaseModel itself.
+    """
+    if not variants:
+        return None
+    bases_per_variant = []
+    for v in variants:
+        bases_per_variant.append(
+            [b for b in v.__mro__ if _is_model(b) and b is not BaseModel]
+        )
+    # Intersect MROs
+    common = set(bases_per_variant[0])
+    for bases in bases_per_variant[1:]:
+        common &= set(bases)
+    # Remove the variant classes themselves
+    common -= set(variants)
+    if not common:
+        return None
+    # Pick the most specific (closest to variants in MRO)
+    # Sort by MRO position of first variant
+    first_mro = bases_per_variant[0]
+    common_sorted = sorted(common, key=lambda c: first_mro.index(c))
+    return common_sorted[0]
+
+
+def _flatten_model(
+    model_cls: type[BaseModel],
+    prefix: str = "",
+    _seen: set | None = None,
+    exclude_fields: set[str] | None = None,
+) -> list[tuple[str, str, str, str, bool]]:
+    """Flatten a pydantic model into (path, type, default, description, is_section) rows."""
+    if _seen is None:
+        _seen = set()
+    if exclude_fields is None:
+        exclude_fields = set()
+
+    if model_cls in _seen:
+        return []
+    _seen.add(model_cls)
+
+    rows = []
+
+    for field_name, field_info in model_cls.model_fields.items():
+        if field_name in exclude_fields:
+            continue
+
+        path = f"{prefix}.{field_name}" if prefix else field_name
+        annotation = _unwrap_annotated(field_info.annotation)
+
+        # --- Union of model classes (discriminated union) ---
+        if _is_union(annotation):
+            members = _get_union_members(annotation)
+            model_members = [m for m in members if _is_model(m)]
+
+            if len(model_members) > 1:
+                # Discriminated union
+                optional = _is_optional(annotation)
+                names = [_get_variant_name(m) or m.__name__ for m in model_members]
+                info_parts = []
+                if optional:
+                    info_parts.append("optional")
+                info_parts.append(f"default: {_default_str(field_info)}")
+                info = ", ".join(info_parts)
+                rows.append((path, f"[{info}]", "", f"variants: {', '.join(names)}", True))
+
+                # Find shared base and emit shared fields once
+                shared_base = _find_shared_base(model_members)
+                if shared_base:
+                    shared_fields = set(shared_base.model_fields.keys())
+                    rows.extend(_flatten_model(shared_base, path, _seen.copy(), set()))
+                else:
+                    shared_fields = set()
+
+                # Emit variant-specific fields
+                for m in model_members:
+                    vname = _get_variant_name(m) or m.__name__
+                    vpath = f"{path}.{vname}"
+                    rows.extend(
+                        _flatten_model(m, vpath, _seen.copy(), exclude_fields=shared_fields)
+                    )
+                continue
+
+            elif len(model_members) == 1:
+                # Optional[SomeModel] — single optional section
+                m = model_members[0]
+                optional = _is_optional(annotation)
+                if optional:
+                    rows.append((path, f"[optional, default: {_default_str(field_info)}]", "", "", True))
+                rows.extend(_flatten_model(m, path, _seen.copy()))
+                continue
+
+        # --- List of models ---
+        item_type = _is_list_of(annotation)
+        if item_type is not None:
+            actual_item = _unwrap_annotated(item_type)
+
+            if _is_union(actual_item):
+                members = _get_union_members(actual_item)
+                model_members = [m for m in members if _is_model(m)]
+            elif _is_model(actual_item):
+                model_members = [actual_item]
+            else:
+                model_members = []
+
+            if model_members:
+                names = [_get_variant_name(m) or m.__name__ for m in model_members]
+                desc = f"variants: {', '.join(names)}" if len(model_members) > 1 else ""
+                rows.append((f"{path}[]", f"[list, default: {_default_str(field_info)}]", "", desc, True))
+
+                if len(model_members) > 1:
+                    shared_base = _find_shared_base(model_members)
+                    shared_fields = set(shared_base.model_fields.keys()) if shared_base else set()
+                    if shared_base:
+                        rows.extend(_flatten_model(shared_base, f"{path}[]", _seen.copy(), set()))
+                    for m in model_members:
+                        vname = _get_variant_name(m) or m.__name__
+                        rows.extend(
+                            _flatten_model(m, f"{path}[].{vname}", _seen.copy(), exclude_fields=shared_fields)
+                        )
+                else:
+                    rows.extend(_flatten_model(model_members[0], f"{path}[]", _seen.copy()))
+                continue
+
+        # --- Nested single model ---
+        if _is_model(annotation):
+            rows.extend(_flatten_model(annotation, path, _seen.copy()))
+            continue
+
+        # --- Leaf field ---
+        rows.append((path, _type_str(annotation), _default_str(field_info), _description(field_info), False))
+
+    _seen.discard(model_cls)
+    return rows
+
+
+def print_flat(model_cls: type[BaseModel]):
+    """Print all parameters of a pydantic config as a flat table."""
+    rows = _flatten_model(model_cls)
+    if not rows:
+        return
+    leaf_rows = [r for r in rows if not r[4]]
+    if leaf_rows:
+        w_path = max(len(r[0]) for r in leaf_rows)
+        w_type = max(len(r[1]) for r in leaf_rows)
+        w_default = max(len(r[2]) for r in leaf_rows)
+    else:
+        w_path = w_type = w_default = 10
+    for path, type_str, default_str, desc, is_section in rows:
+        if is_section:
+            line = f"\n{path:<{w_path}}  {type_str}"
+            if desc:
+                line += f"  {desc}"
+        else:
+            line = f"{path:<{w_path}}  {type_str:<{w_type}}  {default_str:<{w_default}}"
+            if desc:
+                line += f"  {desc}"
+        print(line)

--- a/apax/config/schema_navigation.py
+++ b/apax/config/schema_navigation.py
@@ -1,13 +1,9 @@
-"""JSON schema navigation helpers for --keywords and section drill-down.
-
-These operate on the raw JSON schema dict produced by pydantic's
-model_json_schema(), resolving $ref pointers and walking dotted paths.
-"""
+"""JSON schema navigation for --keywords and section drill-down."""
 
 import json
 
 
-def resolve_ref(node, defs):
+def _resolve(node, defs):
     """Resolve a single $ref pointer."""
     if isinstance(node, dict) and "$ref" in node:
         ref_name = node["$ref"].split("/")[-1]
@@ -16,57 +12,44 @@ def resolve_ref(node, defs):
     return node
 
 
-def shallow_resolve(node, defs):
-    """Resolve $ref pointers one level deep (no recursion into children)."""
-    node = resolve_ref(node, defs)
+def _shallow_resolve(node, defs):
+    """Resolve $ref pointers one level deep."""
+    node = _resolve(node, defs)
     if not isinstance(node, dict):
         return node
-
     result = {}
     for k, v in node.items():
         if k == "properties" and isinstance(v, dict):
-            result[k] = {pk: resolve_ref(pv, defs) for pk, pv in v.items()}
+            result[k] = {pk: _resolve(pv, defs) for pk, pv in v.items()}
         elif k in ("oneOf", "anyOf") and isinstance(v, list):
-            result[k] = [resolve_ref(item, defs) for item in v]
+            result[k] = [_resolve(item, defs) for item in v]
         else:
-            result[k] = resolve_ref(v, defs) if isinstance(v, dict) else v
+            result[k] = _resolve(v, defs) if isinstance(v, dict) else v
     return result
 
 
-def find_variant(node, name, defs):
-    """Find a named variant in a oneOf/anyOf discriminated union."""
+def _iter_variants(node, defs):
+    """Yield (discriminator_name, resolved_node) for oneOf/anyOf variants."""
     for key in ("oneOf", "anyOf"):
-        variants = node.get(key, [])
-        for variant in variants:
-            resolved = resolve_ref(variant, defs)
-            title = resolved.get("title", "").lower().replace("config", "").replace("options", "")
-            variant_name_const = None
+        for variant in node.get(key, []):
+            resolved = _resolve(variant, defs)
+            vname = None
             for prop in resolved.get("properties", {}).values():
                 if "const" in prop:
-                    variant_name_const = prop["const"]
+                    vname = prop["const"]
                     break
-            if name.lower() in (
-                title.strip(),
-                (variant_name_const or "").lower(),
-                resolved.get("title", "").lower(),
-            ):
-                return resolved
-    return None
+            yield vname or resolved.get("title", ""), resolved
 
 
 def filter_schema(schema, section):
-    """Extract a section from the schema, supporting dotted paths like 'model.gmnn'.
-
-    Returns (resolved_node, None) on success, or (None, error_message) on failure.
-    """
+    """Walk dotted path, return (resolved_node, None) or (None, error)."""
     defs = schema.get("$defs", {})
     props = schema.get("properties", {})
-
     parts = section.split(".")
-    first = parts[0]
 
+    first = parts[0]
     if first in props:
-        node = resolve_ref(props[first], defs)
+        node = _resolve(props[first], defs)
     elif first in defs:
         node = defs[first]
     else:
@@ -74,66 +57,50 @@ def filter_schema(schema, section):
         return None, f"Section '{first}' not found. Available: {', '.join(available)}"
 
     for part in parts[1:]:
-        node = resolve_ref(node, defs)
+        node = _resolve(node, defs)
         node_props = node.get("properties", {})
         if part in node_props:
-            node = resolve_ref(node_props[part], defs)
+            node = _resolve(node_props[part], defs)
             continue
-        variant = find_variant(node, part, defs)
-        if variant is not None:
-            node = variant
+        # Try matching as a variant name
+        matched = None
+        for vname, resolved in _iter_variants(node, defs):
+            title = resolved.get("title", "").lower().replace("config", "").replace("options", "")
+            if part.lower() in (title.strip(), vname.lower(), resolved.get("title", "").lower()):
+                matched = resolved
+                break
+        if matched:
+            node = matched
             continue
-        available_parts = sorted(node_props.keys())
-        for key in ("oneOf", "anyOf"):
-            for v in node.get(key, []):
-                resolved = resolve_ref(v, defs)
-                t = resolved.get("title", "")
-                if t:
-                    available_parts.append(t)
+        available_parts = sorted(node_props.keys()) + [n for n, _ in _iter_variants(node, defs)]
         prefix = ".".join(parts[: parts.index(part)])
         return None, f"'{part}' not found in '{prefix}'. Available: {', '.join(sorted(available_parts))}"
 
-    return shallow_resolve(node, defs), None
+    return _shallow_resolve(node, defs), None
 
 
-def list_keywords(node, defs):
-    """List navigable keywords at the current schema node."""
-    node = resolve_ref(node, defs)
-    keywords = []
-    for name, prop in node.get("properties", {}).items():
-        resolved = resolve_ref(prop, defs)
-        desc = resolved.get("description", "")
-        short = desc.split("\n")[0][:80] if desc else ""
-        keywords.append((name, short))
-    for key in ("oneOf", "anyOf"):
-        for variant in node.get(key, []):
-            resolved = resolve_ref(variant, defs)
-            title = resolved.get("title", "")
-            variant_name = None
-            for prop in resolved.get("properties", {}).values():
-                if "const" in prop:
-                    variant_name = prop["const"]
-                    break
-            desc = resolved.get("description", "").split("\n")[0][:80]
-            keywords.append((variant_name or title, desc))
-    return keywords
-
-
-def print_keywords(schema, section, defs):
-    """Resolve path and print keywords at that level."""
+def print_keywords(schema, section):
+    """Print navigable keywords at the given path. Returns error string or None."""
+    defs = schema.get("$defs", {})
     if section:
         node, error = filter_schema(schema, section)
         if error:
             return error
     else:
-        node = schema
-    keywords = list_keywords(node, defs)
+        node = _resolve(schema, defs)
+
+    keywords = []
+    for name, prop in node.get("properties", {}).items():
+        resolved = _resolve(prop, defs)
+        desc = resolved.get("description", "")
+        keywords.append((name, desc.split("\n")[0][:80] if desc else ""))
+    for vname, resolved in _iter_variants(node, defs):
+        desc = resolved.get("description", "").split("\n")[0][:80]
+        keywords.append((vname, desc))
+
     if not keywords:
-        print(json.dumps(shallow_resolve(node, defs), indent=2))
+        print(json.dumps(_shallow_resolve(node, defs), indent=2))
         return None
     for name, desc in keywords:
-        if desc:
-            print(f"  {name:30s} {desc}")
-        else:
-            print(f"  {name}")
+        print(f"  {name:30s} {desc}" if desc else f"  {name}")
     return None

--- a/apax/config/schema_navigation.py
+++ b/apax/config/schema_navigation.py
@@ -1,0 +1,139 @@
+"""JSON schema navigation helpers for --keywords and section drill-down.
+
+These operate on the raw JSON schema dict produced by pydantic's
+model_json_schema(), resolving $ref pointers and walking dotted paths.
+"""
+
+import json
+
+
+def resolve_ref(node, defs):
+    """Resolve a single $ref pointer."""
+    if isinstance(node, dict) and "$ref" in node:
+        ref_name = node["$ref"].split("/")[-1]
+        if ref_name in defs:
+            return defs[ref_name]
+    return node
+
+
+def shallow_resolve(node, defs):
+    """Resolve $ref pointers one level deep (no recursion into children)."""
+    node = resolve_ref(node, defs)
+    if not isinstance(node, dict):
+        return node
+
+    result = {}
+    for k, v in node.items():
+        if k == "properties" and isinstance(v, dict):
+            result[k] = {pk: resolve_ref(pv, defs) for pk, pv in v.items()}
+        elif k in ("oneOf", "anyOf") and isinstance(v, list):
+            result[k] = [resolve_ref(item, defs) for item in v]
+        else:
+            result[k] = resolve_ref(v, defs) if isinstance(v, dict) else v
+    return result
+
+
+def find_variant(node, name, defs):
+    """Find a named variant in a oneOf/anyOf discriminated union."""
+    for key in ("oneOf", "anyOf"):
+        variants = node.get(key, [])
+        for variant in variants:
+            resolved = resolve_ref(variant, defs)
+            title = resolved.get("title", "").lower().replace("config", "").replace("options", "")
+            variant_name_const = None
+            for prop in resolved.get("properties", {}).values():
+                if "const" in prop:
+                    variant_name_const = prop["const"]
+                    break
+            if name.lower() in (
+                title.strip(),
+                (variant_name_const or "").lower(),
+                resolved.get("title", "").lower(),
+            ):
+                return resolved
+    return None
+
+
+def filter_schema(schema, section):
+    """Extract a section from the schema, supporting dotted paths like 'model.gmnn'.
+
+    Returns (resolved_node, None) on success, or (None, error_message) on failure.
+    """
+    defs = schema.get("$defs", {})
+    props = schema.get("properties", {})
+
+    parts = section.split(".")
+    first = parts[0]
+
+    if first in props:
+        node = resolve_ref(props[first], defs)
+    elif first in defs:
+        node = defs[first]
+    else:
+        available = sorted(list(props.keys()) + list(defs.keys()))
+        return None, f"Section '{first}' not found. Available: {', '.join(available)}"
+
+    for part in parts[1:]:
+        node = resolve_ref(node, defs)
+        node_props = node.get("properties", {})
+        if part in node_props:
+            node = resolve_ref(node_props[part], defs)
+            continue
+        variant = find_variant(node, part, defs)
+        if variant is not None:
+            node = variant
+            continue
+        available_parts = sorted(node_props.keys())
+        for key in ("oneOf", "anyOf"):
+            for v in node.get(key, []):
+                resolved = resolve_ref(v, defs)
+                t = resolved.get("title", "")
+                if t:
+                    available_parts.append(t)
+        prefix = ".".join(parts[: parts.index(part)])
+        return None, f"'{part}' not found in '{prefix}'. Available: {', '.join(sorted(available_parts))}"
+
+    return shallow_resolve(node, defs), None
+
+
+def list_keywords(node, defs):
+    """List navigable keywords at the current schema node."""
+    node = resolve_ref(node, defs)
+    keywords = []
+    for name, prop in node.get("properties", {}).items():
+        resolved = resolve_ref(prop, defs)
+        desc = resolved.get("description", "")
+        short = desc.split("\n")[0][:80] if desc else ""
+        keywords.append((name, short))
+    for key in ("oneOf", "anyOf"):
+        for variant in node.get(key, []):
+            resolved = resolve_ref(variant, defs)
+            title = resolved.get("title", "")
+            variant_name = None
+            for prop in resolved.get("properties", {}).values():
+                if "const" in prop:
+                    variant_name = prop["const"]
+                    break
+            desc = resolved.get("description", "").split("\n")[0][:80]
+            keywords.append((variant_name or title, desc))
+    return keywords
+
+
+def print_keywords(schema, section, defs):
+    """Resolve path and print keywords at that level."""
+    if section:
+        node, error = filter_schema(schema, section)
+        if error:
+            return error
+    else:
+        node = schema
+    keywords = list_keywords(node, defs)
+    if not keywords:
+        print(json.dumps(shallow_resolve(node, defs), indent=2))
+        return None
+    for name, desc in keywords:
+        if desc:
+            print(f"  {name:30s} {desc}")
+        else:
+            print(f"  {name}")
+    return None

--- a/apax/config/schema_navigation.py
+++ b/apax/config/schema_navigation.py
@@ -65,16 +65,30 @@ def filter_schema(schema, section):
         # Try matching as a variant name
         matched = None
         for vname, resolved in _iter_variants(node, defs):
-            title = resolved.get("title", "").lower().replace("config", "").replace("options", "")
-            if part.lower() in (title.strip(), vname.lower(), resolved.get("title", "").lower()):
+            title = (
+                resolved.get("title", "")
+                .lower()
+                .replace("config", "")
+                .replace("options", "")
+            )
+            if part.lower() in (
+                title.strip(),
+                vname.lower(),
+                resolved.get("title", "").lower(),
+            ):
                 matched = resolved
                 break
         if matched:
             node = matched
             continue
-        available_parts = sorted(node_props.keys()) + [n for n, _ in _iter_variants(node, defs)]
+        available_parts = sorted(node_props.keys()) + [
+            n for n, _ in _iter_variants(node, defs)
+        ]
         prefix = ".".join(parts[: parts.index(part)])
-        return None, f"'{part}' not found in '{prefix}'. Available: {', '.join(sorted(available_parts))}"
+        return (
+            None,
+            f"'{part}' not found in '{prefix}'. Available: {', '.join(sorted(available_parts))}",
+        )
 
     return _shallow_resolve(node, defs), None
 


### PR DESCRIPTION
Adds some subcommands to apax schema that allow navigating the individual sections of the apax config files. Convenient for agents to understand the nested parameters in the trianing and MD configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New schema subcommands for inspecting and drilling into train and MD configuration parameters, including keyword/section navigation and a flattened parameter view.
  * VS Code schema generation to enable editor autocompletion for config files.
  * Template generation improvements with safer collision checks and an option to auto-fill dummy data during validation.

* **Configuration Changes**
  * Reduced default loss weights in training templates (forces and energy changed from 4.0 to 1.0).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->