### PR TITLE
fix(uq): make uncertainty units & estimator consistent across apax

### DIFF
--- a/apax/layers/properties.py
+++ b/apax/layers/properties.py
@@ -128,7 +128,13 @@ class PropertyHead(nn.Module):
                 result = jnp.swapaxes(result, 0, 1)
 
             mean = jnp.mean(result, axis=0)
-            uncertainty = divisor * fp64_sum((mean - result) ** 2, axis=0)
+            # Bessel-corrected ensemble variance, then converted to a standard
+            # deviation. The `<name>_uncertainty` key is a standard deviation
+            # (sigma) throughout apax: energy/forces store `jnp.sqrt(variance)`
+            # in `apax/nn/models.py`, and `nll_loss`/`crps_loss` in
+            # `apax/train/loss.py` consume the key as sigma.
+            variance = divisor * fp64_sum((mean - result) ** 2, axis=0)
+            uncertainty = jnp.sqrt(variance)
             output[self.pname] = mean
             output[self.pname + "_uncertainty"] = uncertainty
 

--- a/apax/md/ase_calc.py
+++ b/apax/md/ase_calc.py
@@ -110,7 +110,15 @@ def build_hessian_neighbor_fns(
 def make_ensemble(model):
     def ensemble(positions, Z, idx, box, offsets):
         results = model(positions, Z, idx, box, offsets)
-        uncertainty = {k + "_uncertainty": jnp.std(v, axis=0) for k, v in results.items()}
+        # Use the Bessel-corrected sample std 1/(N-1) to stay consistent with
+        # the shallow ensemble (apax/nn/models.py) and PropertyHead paths.
+        # make_ensemble is only wired in when n_models > 1, but guard the
+        # single-model case so ddof=1 cannot divide by zero -> NaN.
+        ddof = {k: 1 if jnp.shape(v)[0] > 1 else 0 for k, v in results.items()}
+        uncertainty = {
+            k + "_uncertainty": jnp.std(v, axis=0, ddof=ddof[k])
+            for k, v in results.items()
+        }
         ensemble = {k + "_ensemble": v for k, v in results.items()}
         results = {k: jnp.mean(v, axis=0) for k, v in results.items()}
         if "forces_ensemble" in ensemble.keys():

--- a/tests/unit_tests/layers/test_properties.py
+++ b/tests/unit_tests/layers/test_properties.py
@@ -98,3 +98,46 @@ def test_property_head(setup_data):
     output = property_head.apply(params, g, R, dr_vec, Z, idx, box)
     assert "property" in output.keys()
     assert "property_uncertainty" in output
+
+
+def test_property_head_uncertainty_is_std(setup_data):
+    """The `<name>_uncertainty` output must be a standard deviation.
+
+    The rest of apax (energy/forces in ``apax/nn/models.py`` and the
+    ``nll_loss``/``crps_loss`` consumers in ``apax/train/loss.py``) treats the
+    ``<name>_uncertainty`` key as a standard deviation (sigma), not a variance.
+    This regression test pins ``PropertyHead`` to that convention using the
+    Bessel-corrected (``1/(n_ens - 1)``) estimator.
+    """
+    g, R, dr_vec, Z, idx, box = setup_data
+
+    n_ens = 10
+    property_head = PropertyHead(
+        pname="property",
+        readout=AtomisticReadout(n_shallow_ensemble=n_ens),
+        mode="l0",
+        apply_mask=False,
+        aggregation="mean",
+    )
+    params = property_head.init(jax.random.PRNGKey(0), g, R, dr_vec, Z, idx, box)
+    output = property_head.apply(params, g, R, dr_vec, Z, idx, box)
+
+    # Reproduce the per-ensemble-member predictions (aggregation="mean") so we
+    # can compute the expected std independently of the head's reduction.
+    readout_params = {"params": params["params"]["readout"]}
+    h = jax.vmap(lambda x: property_head.readout.apply(readout_params, x))(
+        g
+    )  # (n_atoms, n_ens)
+    scale = params["params"]["scale_per_element"]
+    shift = params["params"]["shift_per_element"]
+    p_i = h * scale[Z] + shift[Z]  # (n_atoms, n_ens)
+    members = jnp.mean(p_i, axis=0)  # (n_ens,), aggregation="mean"
+
+    mean = jnp.mean(members)
+    variance = (1 / (n_ens - 1)) * jnp.sum((mean - members) ** 2)
+    expected_std = jnp.sqrt(variance)
+
+    uncertainty = output["property_uncertainty"]
+    # Must equal the std, NOT the variance.
+    assert jnp.allclose(uncertainty, expected_std)
+    assert not jnp.allclose(uncertainty, variance)

--- a/tests/unit_tests/md/test_ase_calc.py
+++ b/tests/unit_tests/md/test_ase_calc.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import jax.numpy as jnp
+
 from apax.config.model_config import (
     FullEnsembleConfig,
     GMNNConfig,
@@ -8,7 +10,7 @@ from apax.config.model_config import (
     ShallowEnsembleConfig,
 )
 from apax.config.train_config import Config
-from apax.md.ase_calc import ASECalculator
+from apax.md.ase_calc import ASECalculator, make_ensemble
 
 
 def get_mock_config(
@@ -184,3 +186,38 @@ def test_shallow_and_property_head_ensemble():
         "dipole_ensemble",
     ]
     assert sorted(calc.implemented_properties) == sorted(expected_properties)
+
+
+def test_make_ensemble_uses_sample_std():
+    """make_ensemble (deep ensemble) must report the Bessel-corrected
+    sample std 1/(N-1), consistent with the shallow ensemble and
+    PropertyHead paths -- not the 1/N population std."""
+    energy_ens = jnp.asarray([1.0, 2.0, 4.0, 7.0])  # N = 4 stacked models
+    forces_ens = jnp.asarray(
+        [
+            [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]],
+            [[1.0, 0.0, 2.0], [0.0, 2.0, 1.0]],
+            [[2.0, 1.0, 0.0], [3.0, 0.0, 2.0]],
+            [[0.0, 3.0, 1.0], [1.0, 1.0, 4.0]],
+        ]
+    )
+
+    def stacked_model(positions, Z, idx, box, offsets):
+        return {"energy": energy_ens, "forces": forces_ens}
+
+    ensemble_fn = make_ensemble(stacked_model)
+    results = ensemble_fn(None, None, None, None, None)
+
+    expected_energy_unc = jnp.std(energy_ens, axis=0, ddof=1)
+    population_energy_unc = jnp.std(energy_ens, axis=0)  # ddof=0
+
+    # Reported uncertainty must equal the sample std ...
+    assert jnp.allclose(results["energy_uncertainty"], expected_energy_unc)
+    # ... and must NOT equal the population std (guards against regression).
+    assert not jnp.allclose(results["energy_uncertainty"], population_energy_unc)
+
+    expected_forces_unc = jnp.std(forces_ens, axis=0, ddof=1)
+    assert jnp.allclose(results["forces_uncertainty"], expected_forces_unc)
+
+    # Mean must be unchanged by the estimator switch.
+    assert jnp.allclose(results["energy"], jnp.mean(energy_ens, axis=0))


### PR DESCRIPTION
> [!NOTE]
> This issue came up doing some Clauding. Need to verify if it is actually a problem

## The bug

`PropertyHead.__call__` in `apax/layers/properties.py` wrote a **variance** to the `<name>_uncertainty` output key, while the rest of apax treats `<name>_uncertainty` as a **standard deviation (sigma)**.

The old code:

```python
divisor = 1 / (n_ens - 1)
mean = jnp.mean(result, axis=0)
uncertainty = divisor * fp64_sum((mean - result) ** 2, axis=0)  # variance, not std
output[self.pname + "_uncertainty"] = uncertainty
```

## Convention evidence (the rest of apax uses sigma)

- **energy** — `apax/nn/models.py`: `"energy_uncertainty": jnp.sqrt(energy_variance)` (std)
- **forces** — `apax/nn/models.py`: `prediction["forces_uncertainty"] = jnp.sqrt(forces_variance)` (std)
- **`nll_loss`** — `apax/train/loss.py`: reads `sigmas = prediction[name + "_uncertainty"]` then squares it (`variances = sigmas**2`); docstring says "standard deviations".
- **`crps_loss`** — `apax/train/loss.py`: uses `sigmas` directly as the Gaussian scale.

So a property head emitting a variance under that key made NLL/CRPS-on-properties the wrong objective and handed downstream consumers wrong-unit values.

## The fix

Compute the (Bessel-corrected) ensemble variance, then return its square root so `<name>_uncertainty` is a standard deviation, matching the energy/forces convention:

```python
variance = divisor * fp64_sum((mean - result) ** 2, axis=0)
uncertainty = jnp.sqrt(variance)
```

A focused regression test in `tests/unit_tests/layers/test_properties.py` asserts the output equals `sqrt((1/(n_ens-1)) * sum((mean-result)^2))` (the std) and not the variance.

## Scope

- Affects **all** models with property heads (GMNN / So3krates / EquivMP / MACE) — `PropertyHead` is framework-wide shared code.
- The `1/(N-1)` (Bessel-corrected) estimator is **unchanged**.
- `make_ensemble` in `apax/md/ase_calc.py` is addressed in a **second commit** in this PR (see below).


---

## Second fix: `make_ensemble` deep-ensemble std (1/N -> 1/(N-1))

After landing the `PropertyHead` fix above, the **last** remaining inconsistent UQ estimator in apax was `make_ensemble` in `apax/md/ase_calc.py` — the deep-ensemble (stacked multi-checkpoint) wrapper used by all model types (GMNN / So3krates / EquivMP / MACE), not MACE-specific.

It computed reported uncertainties with:

```python
uncertainty = {k + "_uncertainty": jnp.std(v, axis=0) for k, v in results.items()}
```

`jnp.std` defaults to `ddof=0`, i.e. the **1/N population std**. Every other UQ path uses the **Bessel-corrected 1/(N-1) sample std**:

- ShallowEnsembleModel energy/forces — `apax/nn/models.py` (`divisor = 1 / (n_ens - 1)`)
- `PropertyHead` — `apax/layers/properties.py` (after the first commit in this PR)
- upstream MACE PR #800

The second commit switches `make_ensemble` to `ddof=1`:

```python
ddof = {k: 1 if jnp.shape(v)[0] > 1 else 0 for k, v in results.items()}
uncertainty = {
    k + "_uncertainty": jnp.std(v, axis=0, ddof=ddof[k]) for k, v in results.items()
}
```

`make_ensemble` is only wired in when `n_models > 1` at every call site (`ase_calc.py`, `openmm_interface.py`, `simulate.py`), so `ddof=1` is always well-defined; the guard simply falls back to `ddof=0` for a length-1 model axis to avoid a divide-by-zero NaN.

**Impact:** this changes reported deep-ensemble uncertainties for existing multi-checkpoint setups — sigma becomes `sqrt(N/(N-1))` larger (~6.7% at N=8). Regression test `test_make_ensemble_uses_sample_std` in `tests/unit_tests/md/test_ase_calc.py` pins the 1/(N-1) value and guards against the 1/N regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)