### PR TITLE
Add custom mass dynamics

### DIFF
--- a/apax/config/md_config.py
+++ b/apax/config/md_config.py
@@ -323,6 +323,11 @@ class MDConfig(BaseModel, frozen=True, extra="forbid"):
     extra_capacity : int, default = 0
         | JaxMD allocates a maximal number of neighbors. This argument lets you add
         | additional capacity to avoid recompilation. The default is usually fine.
+    custom_element_masses : dict[str, float | str], default = {}
+        | Dictionary of custom atomic masses, with the keys being the elements,
+        | and the values either being numbers to indicate its mass, or strings
+        | to indicate that this the element indicated by the key has the same mass as
+        | the default mass of the element indicated by the value.
 
     biases : list[BiasEnergy]
         | List of bias energies. Currently a spherical wall potential is available.
@@ -367,6 +372,7 @@ class MDConfig(BaseModel, frozen=True, extra="forbid"):
     dr_threshold: PositiveFloat = 0.5
     extra_capacity: NonNegativeInt = 0
     disable_cell_list: bool = False
+    custom_element_masses: dict[str, float | str] = {}
 
     biases: list[BiasEnergy] = []
     dynamics_checks: list[DynamicsCheck] = []

--- a/apax/md/schedules.py
+++ b/apax/md/schedules.py
@@ -4,8 +4,8 @@ from ase import units
 
 
 class TSchedule:
-    def __init__(self, T0: int):
-        self.T0 = T0
+    def __init__(self, T0: int | float):
+        self.T0 = float(T0)
 
     def __call__(self, step) -> float:
         raise NotImplementedError
@@ -17,8 +17,8 @@ class ConstantTSchedule(TSchedule):
 
 
 class PieceWiseLinearTSchedule(TSchedule):
-    def __init__(self, T0: int, temperatures: list[float], durations: list[int]):
-        self.T0 = T0
+    def __init__(self, T0: int | float, temperatures: list[float], durations: list[int]):
+        self.T0 = float(T0)
         self.temperatures = jnp.array(temperatures)
         steps = np.cumsum(durations)
         self.steps = jnp.array(steps)
@@ -33,13 +33,13 @@ class PieceWiseLinearTSchedule(TSchedule):
 class OscillatingRampTSchedule(TSchedule):
     def __init__(
         self,
-        T0: int,
+        T0: int | float,
         Tend: float,
         amplitude: float,
         num_oscillations: int,
         total_steps: int,
     ):
-        self.T0 = T0
+        self.T0 = float(T0)
         self.Tend = Tend
         self.amplitude = amplitude
         self.num_oscillations = num_oscillations

--- a/apax/md/simulate.py
+++ b/apax/md/simulate.py
@@ -7,14 +7,13 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import orbax.checkpoint as ocp
-from ase import units, Atoms
+from ase import Atoms, units
 from ase.io import read
 from jax.experimental import io_callback
 from jax_md import partition, quantity, simulate, space
 from tqdm import trange
 from tqdm.contrib.logging import logging_redirect_tqdm
 
-from apax.utils.helpers import get_masses
 from apax.config import Config, MDConfig, parse_config
 from apax.config.md_config import Integrator
 from apax.md.ase_calc import make_ensemble, maybe_vmap
@@ -33,6 +32,7 @@ from apax.train.checkpoints import (
     restore_parameters,
 )
 from apax.train.run import setup_logging
+from apax.utils.helpers import get_masses
 
 log = logging.getLogger(__name__)
 

--- a/apax/md/simulate.py
+++ b/apax/md/simulate.py
@@ -7,13 +7,14 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import orbax.checkpoint as ocp
-from ase import units
+from ase import units, Atoms
 from ase.io import read
 from jax.experimental import io_callback
 from jax_md import partition, quantity, simulate, space
 from tqdm import trange
 from tqdm.contrib.logging import logging_redirect_tqdm
 
+from apax.utils.helpers import get_masses
 from apax.config import Config, MDConfig, parse_config
 from apax.config.md_config import Integrator
 from apax.md.ase_calc import make_ensemble, maybe_vmap
@@ -484,7 +485,9 @@ def md_setup(model_config: Config, md_config: MDConfig):
         Shift function for the integrator.
     """
     log.info("reading structure")
-    atoms = read(md_config.initial_structure)
+    atoms: Atoms = read(md_config.initial_structure)
+    atoms.set_masses(masses=get_masses(md_config.custom_element_masses, atoms))
+
     system = System.from_atoms(atoms)
 
     r_max = model_config.model.basis.r_max

--- a/apax/utils/helpers.py
+++ b/apax/utils/helpers.py
@@ -127,11 +127,15 @@ def get_ase_mass(symbol_or_mass: str | int | float) -> float:
         float: Mass of element.
 
     Raises:
-        ValueError: If `symbol`or_mass` is an integer or float that is less
+        ValueError: If `symbol_or_mass` is an integer or float that is less
             than or equal to 0.
+        TypeError: If `symbol_or_mass` is not a string, integer or float.
 
     """
     if isinstance(symbol_or_mass, str):
+        if symbol_or_mass not in atomic_numbers:
+            msg = f"Unknown element symbol '{symbol_or_mass}'."
+            raise ValueError(msg)
         atomic_number = atomic_numbers[symbol_or_mass]
         return atomic_masses[atomic_number]
     elif isinstance(symbol_or_mass, int | float):
@@ -140,7 +144,9 @@ def get_ase_mass(symbol_or_mass: str | int | float) -> float:
             raise ValueError(msg)
         return float(symbol_or_mass)
     else:
-        raise TypeError
+        raise TypeError(
+            f"Expected a string or number for mass, got {type(symbol_or_mass)}."
+        )
 
 
 def get_updated_atomic_masses(
@@ -158,22 +164,15 @@ def get_updated_atomic_masses(
     Returns:
         atomic_masses_cpy (np.ndarray): Array with the updated atomic masses.
 
-    Raises:
-        ValueError: If duplicate elements are found in `custom_mass_dictionary`.
-
     """
     atomic_masses_cpy = atomic_masses.copy()
-    seen_elements = set()
     for element, symbol_or_mass in custom_mass_dictionary.items():
-        if element in seen_elements:
-            msg = f"Duplicate element {element} encountered in custom mass dictionary."
-            raise ValueError(msg)
-        seen_elements.add(element)
-
-        log.info(f"Setting mass of element {element} to {symbol_or_mass}")
-        custom_mass_dictionary[element] = get_ase_mass(symbol_or_mass)
+        element_mass = get_ase_mass(symbol_or_mass)
         atomic_number = atomic_numbers[element]
-        atomic_masses_cpy[atomic_number] = custom_mass_dictionary[element]
+        log.info(
+            f"Setting mass of element {element} (atomic number {atomic_number}) to {symbol_or_mass}"
+        )
+        atomic_masses_cpy[atomic_number] = element_mass
 
     return atomic_masses_cpy
 

--- a/apax/utils/helpers.py
+++ b/apax/utils/helpers.py
@@ -1,9 +1,13 @@
 import collections
 import csv
+import logging
 from pathlib import Path
 from typing import Any, Union
+from ase.data import atomic_numbers, atomic_masses, atomic_numbers
 
+from ase import Atoms, Atom
 import yaml
+import numpy as np
 
 # default whitelist of properties for jaxMD
 APAX_PROPERTIES = [
@@ -21,6 +25,9 @@ APAX_PROPERTIES = [
     "charge",
     "charges",
 ]
+
+
+log = logging.getLogger(__name__)
 
 
 def mod_config(
@@ -105,3 +112,93 @@ def update_nested_dictionary(dct: dict, other: dict) -> dict:
         else:
             dct[k] = v
     return dct
+
+
+def get_ase_mass(symbol_or_mass: str | int | float) -> float:
+    """Get the mass in ASE, or just return the mass.
+
+    Simply returns the value if `symbol_or_mass` is an integer or float,
+    and otherwise returns the mass that element has in ASE.
+
+    Args:
+        symbol_or_mass (str | int | float): The symbol, or mass.
+
+    Returns:
+        float: Mass of element.
+
+    Raises:
+        ValueError: If `symbol`or_mass` is an integer or float that is less
+            than or equal to 0.
+
+    """
+    if isinstance(symbol_or_mass, str):
+        atomic_number = atomic_numbers[symbol_or_mass]
+        return atomic_masses[atomic_number]
+    elif isinstance(symbol_or_mass, int | float):
+        if symbol_or_mass <= 0:
+            msg = f"The provided mass is less than 0 ({symbol_or_mass})."
+            raise ValueError(msg)
+        return float(symbol_or_mass)
+    else:
+        raise TypeError
+
+
+def get_updated_atomic_masses(
+    custom_mass_dictionary: dict[str, float | str],
+) -> np.ndarray:
+    """Get an updated list of custom atomic masses.
+
+    Args:
+        custom_mass_dictionary (dict[str, float | str]): Dictionary of custom
+            atomic masses, with the keys being the elements, and the values
+            either being numbers to indicate its mass, or strings to indicate that
+            this the element indicated by the key has the same mass as the element in
+            the value.
+
+    Returns:
+        atomic_masses_cpy (np.ndarray): Array with the updated atomic masses.
+
+    Raises:
+        ValueError: If duplicate elements are found in `custom_mass_dictionary`.
+
+    """
+    atomic_masses_cpy = atomic_masses.copy()
+    seen_elements = set()
+    for element, symbol_or_mass in custom_mass_dictionary.items():
+        if element in seen_elements:
+            msg = f"Duplicate element {element} encountered in custom mass dictionary."
+            raise ValueError(msg)
+        seen_elements.add(element)
+
+        log.info(f"Setting mass of element {element} to {symbol_or_mass}")
+        custom_mass_dictionary[element] = get_ase_mass(symbol_or_mass)
+        atomic_number = atomic_numbers[element]
+        atomic_masses_cpy[atomic_number] = custom_mass_dictionary[element]
+
+    return atomic_masses_cpy
+
+
+def get_masses(
+    custom_mass_dictionary: dict[str, float | str], atoms: Atoms
+) -> np.ndarray:
+    """Get the masses of all atoms in `atoms`.
+
+    Args:
+        custom_mass_dictionary (dict[str, float | str]): Dictionary of custom
+            atomic masses, with the keys being the elements, and the values
+            either being numbers to indicate its mass, or strings to indicate that
+            this the element indicated by the key has the same mass as the element in
+            the value.
+        atoms (Atoms): Atoms to get the masses for.
+
+    Returns:
+        np.ndarray: Masses of all atoms in `atoms`.
+
+    """
+    atomic_masses = get_updated_atomic_masses(custom_mass_dictionary)
+
+    masses = []
+    for atom in atoms:
+        masses.append(atomic_masses[atom.number])
+
+    return np.array(masses)

--- a/apax/utils/helpers.py
+++ b/apax/utils/helpers.py
@@ -3,11 +3,11 @@ import csv
 import logging
 from pathlib import Path
 from typing import Any, Union
-from ase.data import atomic_numbers, atomic_masses, atomic_numbers
 
-from ase import Atoms, Atom
-import yaml
 import numpy as np
+import yaml
+from ase import Atoms
+from ase.data import atomic_masses, atomic_numbers
 
 # default whitelist of properties for jaxMD
 APAX_PROPERTIES = [

--- a/tests/integration_tests/md/test_md.py
+++ b/tests/integration_tests/md/test_md.py
@@ -15,6 +15,7 @@ from jax_md import partition, space
 
 from apax.config import Config, MDConfig
 from apax.md import run_md
+from apax.md.simulate import md_setup
 from apax.md.ase_calc import ASECalculator
 from apax.md.function_transformations import UncertaintyDrivenDynamics
 from apax.utils import math
@@ -306,3 +307,37 @@ def test_biased_jaxmd(get_tmp_path, example_dataset):
     assert results["energy"] == results["energy_unbiased"] + 0.5 * 1.0 * np.sum(
         np.clip(space.distance(positions) - 1.0, a_min=0, a_max=None) ** 2
     )
+
+
+@pytest.mark.parametrize("num_data", (30,))
+def test_custom_mass_dynamics(get_tmp_path, example_dataset):
+    model_confg_path = TEST_PATH / "config.yaml"
+    working_dir = get_tmp_path / str(uuid.uuid4())
+    data_path = get_tmp_path / "ds.extxyz"
+
+    write(data_path, example_dataset)
+
+    data_config_mods = {
+        "data": {
+            "directory": working_dir.as_posix(),
+            "experiment": "model",
+            "data_path": data_path.as_posix(),
+        },
+    }
+    model_config_dict = load_config_and_run_training(model_confg_path, data_config_mods)
+
+    md_confg_path = TEST_PATH / "md_config.yaml"
+
+    with open(md_confg_path.as_posix(), "r") as stream:
+        md_config_dict = yaml.safe_load(stream)
+    md_config_dict["sim_dir"] = get_tmp_path.as_posix()
+    md_config_dict["initial_structure"] = get_tmp_path.as_posix() + "/ds.extxyz"
+    md_config_dict["custom_element_masses"] = {"H": 4}
+    md_config = MDConfig.model_validate(md_config_dict)
+
+    model_config = Config.model_validate(model_config_dict)
+
+    system, _sym_fns = md_setup(model_config, md_config)
+
+    expected_masses = np.array([4, 4])
+    assert np.all(system.masses == expected_masses)

--- a/tests/integration_tests/md/test_md.py
+++ b/tests/integration_tests/md/test_md.py
@@ -15,9 +15,9 @@ from jax_md import partition, space
 
 from apax.config import Config, MDConfig
 from apax.md import run_md
-from apax.md.simulate import md_setup
 from apax.md.ase_calc import ASECalculator
 from apax.md.function_transformations import UncertaintyDrivenDynamics
+from apax.md.simulate import md_setup
 from apax.utils import math
 from tests.conftest import load_config_and_run_training
 

--- a/tests/unit_tests/utils/test_helpers.py
+++ b/tests/unit_tests/utils/test_helpers.py
@@ -1,4 +1,13 @@
-from apax.utils.helpers import update_nested_dictionary
+from apax.utils.helpers import (
+    update_nested_dictionary,
+    get_masses,
+    get_ase_mass,
+    get_updated_atomic_masses,
+)
+import pytest
+import numpy as np
+from ase.data import atomic_masses
+from ase import Atoms
 
 
 def test_update_nested_dictionary():
@@ -7,3 +16,39 @@ def test_update_nested_dictionary():
     expected_dict = {"a": 1, "b": {"c": 4, "d": {"e": 3}, "f": 5}}
     updated_dict = update_nested_dictionary(d1, d2)
     assert updated_dict == expected_dict
+
+
+get_ase_mass_data = [("He", 4.0), (10, 10), ("H", 1.0)]
+
+
+@pytest.mark.parametrize("symbol_or_mass, expected_mass", get_ase_mass_data)
+def test_get_ase_mass(symbol_or_mass, expected_mass):
+    mass = get_ase_mass(symbol_or_mass)
+    assert np.isclose(mass, expected_mass, atol=1e-2)
+
+
+get_updated_atomic_masses_data = [({}, atomic_masses)]
+
+
+@pytest.mark.parametrize(
+    "custom_mass_dictionary, expected_atomic_masses", get_updated_atomic_masses_data
+)
+def test_get_updated_atomic_masses(custom_mass_dictionary, expected_atomic_masses):
+    updated_atomic_masses = get_updated_atomic_masses(custom_mass_dictionary)
+    assert np.allclose(updated_atomic_masses, expected_atomic_masses)
+    pass
+
+
+get_masses_data = [
+    ({"H": 2, "O": 0.5}, Atoms("OH2"), np.array([0.5, 2, 2])),
+    ({"H": "O", "O": 0.5}, Atoms("OH2"), np.array([0.5, 16, 16])),
+    ({}, Atoms("OH2"), np.array([16, 1, 1])),
+]
+
+
+@pytest.mark.parametrize(
+    "custom_mass_dictionary, atoms, expected_masses", get_masses_data
+)
+def test_get_masses(custom_mass_dictionary, atoms, expected_masses):
+    masses = get_masses(custom_mass_dictionary, atoms)
+    assert np.allclose(masses, expected_masses, atol=1e-2)

--- a/tests/unit_tests/utils/test_helpers.py
+++ b/tests/unit_tests/utils/test_helpers.py
@@ -1,13 +1,14 @@
-from apax.utils.helpers import (
-    update_nested_dictionary,
-    get_masses,
-    get_ase_mass,
-    get_updated_atomic_masses,
-)
-import pytest
 import numpy as np
-from ase.data import atomic_masses
+import pytest
 from ase import Atoms
+from ase.data import atomic_masses
+
+from apax.utils.helpers import (
+    get_ase_mass,
+    get_masses,
+    get_updated_atomic_masses,
+    update_nested_dictionary,
+)
 
 
 def test_update_nested_dictionary():


### PR DESCRIPTION
Adds custom mass dynamics, which could be used for example to set the mass of hydrogen to 2 or 4, to be able to reach larger timesteps in dynamics of protein (although the more accurate hydrogen mass repartitioning is a bit more involved). Alternatively, it allows to be able to label different types of atoms (but the same element, just in different bonding environments) differently, but still have the correct dynamics.

The configuration below sets the mass of hydrogen to 2, and the mass of carbon atoms (just as a showcase) to the mass of hydrogen, which is 1.008 in ASE. All other masses are kept as their default values.

```yaml
ensemble:
  name: nvt
  dt: 0.05 # fs time step
  temperature_schedule:
    name: constant
    T0: 5 # K

duration: 0.25
n_inner: 1
sampling_rate: 1
checkpoint_interval: 2
restart: True
custom_element_masses:
   - H: 2
   - C: H
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for customizing atomic masses in MD simulations.
  * Temperature schedules now accept decimal starting temperatures, making setup more flexible.

* **Bug Fixes**
  * MD runs now apply the configured atomic masses to the initial system instead of relying on defaults.
  * Improved handling of mass inputs by accepting either numeric values or existing element-based defaults.

* **Tests**
  * Added coverage for custom mass configuration and mass-handling helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->